### PR TITLE
Add more solar sensors for River Pro

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -75,6 +75,8 @@ TOTAL_IN_POWER = "Total In Power"
 SOLAR_IN_POWER = "Solar In Power"
 AC_IN_POWER = "AC In Power"
 TYPE_C_IN_POWER = "Type-C In Power"
+SOLAR_IN_CURRENT = "Solar In Current"
+SOLAR_IN_VOLTAGE = "Solar In Voltage"
 
 TOTAL_OUT_POWER = "Total Out Power"
 AC_OUT_POWER = "AC Out Power"

--- a/custom_components/ecoflow_cloud/devices/river_pro.py
+++ b/custom_components/ecoflow_cloud/devices/river_pro.py
@@ -4,7 +4,7 @@ from ..mqtt.ecoflow_mqtt import EcoflowMQTTClient
 from ..number import MaxBatteryLevelEntity
 from ..select import DictSelectEntity
 from ..sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity
+    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, InVoltSensorEntity, InAmpSensorEntity
 from ..switch import EnabledEntity, BeeperEntity
 
 
@@ -14,6 +14,9 @@ class RiverPro(BaseDevice):
             LevelSensorEntity(client, "pd.soc", const.MAIN_BATTERY_LEVEL),
             WattsSensorEntity(client, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
+
+            InAmpSensorEntity(client, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            InVoltSensorEntity(client, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, "inv.inputWatts", const.AC_IN_POWER),
 

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from homeassistant.components.sensor import (SensorDeviceClass, SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (PERCENTAGE, POWER_WATT, ELECTRIC_POTENTIAL_MILLIVOLT,
-                                 TEMP_CELSIUS, UnitOfTime)
+from homeassistant.const import (PERCENTAGE, POWER_WATT, TEMP_CELSIUS, 
+                                 UnitOfElectricPotential, UnitOfElectricCurrent, UnitOfTime)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -66,10 +66,16 @@ class TempSensorEntity(BaseSensorEntity):
 class VoltSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.VOLTAGE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_native_unit_of_measurement = ELECTRIC_POTENTIAL_MILLIVOLT
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.MILLIVOLT
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_value = 0
 
+class AmpSensorEntity(BaseSensorEntity):
+    _attr_device_class = SensorDeviceClass.CURRENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.MILLIAMPERE 
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_value = 0
 
 class WattsSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.POWER
@@ -84,3 +90,9 @@ class InWattsSensorEntity(WattsSensorEntity):
 
 class OutWattsSensorEntity(WattsSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"
+
+class InVoltSensorEntity(VoltSensorEntity):
+    _attr_icon = "mdi:transmission-tower-import"
+
+class InAmpSensorEntity(AmpSensorEntity):
+    _attr_icon = "mdi:transmission-tower-import"


### PR DESCRIPTION
Hey, thank you for publishing this integration! Super helpful now since my local-only one stopped working with firmware updates etc.

I wanted to get solar-specific input monitoring for my River Pro and saw there were `inv.dcInAmp` and `inv.dcInVol` variables available, reported in mA and mV in the raw data.

- Adds two sensors for those
- (That required filling out sensor entity types)
- Updates deprecated `ELECTRIC_POTENTIAL_MILLIVOLT` to use `UnitOfElectricPotential` as [recommended by the HA const file](https://github.com/home-assistant/core/blob/c0d0c89293df8e15b4288e0a4064291f77495aca/homeassistant/const.py#L558)

Works for me:

<img width="385" alt="Screenshot 2023-04-30 at 5 03 51 PM" src="https://user-images.githubusercontent.com/510073/235382326-ed4f1cc5-77ca-4dc1-b184-fb23f31f4f35.png">

Open to edits and/or figuring out the following..
- A cumulative kWh sensor for solar production would be great for plugging into HA's energy dashboard (I may poke around a bit.. `pd.chgSunPower`??)
- Is there a straightforward way in here to multiply those `V * A` to publish a sensor for total solar watts in? As far as I can tell this isn't in the raw data payload but would be useful
- Suggest different default icon(s)?
