### PR TITLE
Add Backup Reserve configuration for Delta 2 and Delta Pro

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -129,6 +129,7 @@ SLAVE_MAX_CELL_VOLT = "Slave Max Cell Volts"
 
 MAX_CHARGE_LEVEL = "Max Charge Level"
 MIN_DISCHARGE_LEVEL = "Min Discharge Level"
+BACKUP_RESERVE_LEVEL = "Backup Reserve Level"
 AC_CHARGING_POWER = "AC Charging Power"
 SCREEN_TIMEOUT = "Screen Timeout"
 UNIT_TIMEOUT = "Unit Timeout"
@@ -145,6 +146,7 @@ DC_ENABLED = "DC (12V) Enabled"
 XBOOST_ENABLED = "X-Boost Enabled"
 AC_ALWAYS_ENABLED = "AC Always On"
 PV_PRIO = "Prio Solar Charging"
+BP_ENABLED = "Backup Reserve Enabled"
 
 DC_MODE = "DC Mode"
 

--- a/custom_components/ecoflow_cloud/devices/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/delta2.py
@@ -76,6 +76,10 @@ class Delta2(BaseDevice):
                                   lambda value: {"moduleType": 2, "operateType": "dsgCfg",
                                                  "params": {"minDsgSoc": int(value)}}),
 
+            MaxBatteryLevelEntity(client, "pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 10, 85,
+                                  lambda value: {"moduleType": 1, "operateType": "watthConfig",
+                                                 "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0, "minChgSoc": 0}}),
+
             MinGenStartLevelEntity(client, "bms_emsStatus.minOpenOilEb", const.GEN_AUTO_START_LEVEL, 0, 30,
                                    lambda value: {"moduleType": 2, "operateType": "closeOilSoc",
                                                   "params": {"closeOilSoc": value}}),
@@ -117,6 +121,8 @@ class Delta2(BaseDevice):
             EnabledEntity(client, "pd.carState", const.DC_ENABLED,
                           lambda value: {"moduleType": 5, "operateType": "mpptCar", "params": {"enabled": value}}),
 
+            EnabledEntity(client, "pd.bpPowerSoc", const.BP_ENABLED,
+                          lambda value: {"moduleType": 1, "operateType": "watthConfig", "params": {"isConfig": value}}),
         ]
 
     def selects(self, client: EcoflowMQTTClient) -> list[BaseSelectEntity]:

--- a/custom_components/ecoflow_cloud/devices/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/delta_pro.py
@@ -101,7 +101,9 @@ class DeltaPro(BaseDevice):
                           lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
 
             EnabledEntity(client, "inv.acPassByAutoEn", const.AC_ALWAYS_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 84, "enabled": value}})
+                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 84, "enabled": value}}),
+            EnabledEntity(client, "pd.bpPowerSoc", const.BP_ENABLED,
+                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"isConfig": value}}),
         ]
 
     def selects(self, client: EcoflowMQTTClient) -> list[BaseSelectEntity]:

--- a/custom_components/ecoflow_cloud/devices/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/delta_pro.py
@@ -69,7 +69,9 @@ class DeltaPro(BaseDevice):
             MinBatteryLevelEntity(client, "ems.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
                                   lambda value: {"moduleType": 0, "operateType": "TCP",
                                                  "params": {"id": 51, "minDsgSoc": value}}),
-
+            MaxBatteryLevelEntity(client, "pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 10, 85,
+                                  lambda value: {"moduleType": 0, "operateType": "TCP",
+                                                 "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0, "maxChgSoc": 0, "id": 94}}),
             MinGenStartLevelEntity(client, "ems.minOpenOilEbSoc", const.GEN_AUTO_START_LEVEL, 0, 30,
                                    lambda value: {"moduleType": 0, "operateType": "TCP",
                                                   "params": {"openOilSoc": value, "id": 52}}),


### PR DESCRIPTION
Backup Reserve I think is now the single place to configure automatic switching between UPS, passthrough, and solar mode.  Its been very helpful for me in setting up schedules for charging and discharging, simply by changing the backup reserve level.