### PR TITLE
River Pro: Add support for secondary battery, expose internal battery rate amps

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -157,3 +157,6 @@ MAX_CELL_TEMP = "Max Cell Temperature"
 BATTERY_VOLT = "Battery Volts"
 MIN_CELL_VOLT = "Min Cell Volts"
 MAX_CELL_VOLT = "Max Cell Volts"
+
+BATTERY_AMP = "Battery Current"
+SLAVE_BATTERY_AMP = "Slave Battery Current"

--- a/custom_components/ecoflow_cloud/devices/river_pro.py
+++ b/custom_components/ecoflow_cloud/devices/river_pro.py
@@ -4,8 +4,8 @@ from ..mqtt.ecoflow_mqtt import EcoflowMQTTClient
 from ..number import MaxBatteryLevelEntity
 from ..select import DictSelectEntity
 from ..sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, InVoltSensorEntity, InAmpSensorEntity, \
-    StatusSensorEntity
+    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InVoltSensorEntity, \
+    InAmpSensorEntity, AmpSensorEntity, StatusSensorEntity
 from ..switch import EnabledEntity, BeeperEntity
 
 
@@ -32,8 +32,27 @@ class RiverPro(BaseDevice):
 
             RemainSensorEntity(client, "pd.remainTime", const.REMAINING_TIME),
             TempSensorEntity(client, "bmsMaster.temp", const.BATTERY_TEMP),
+            TempSensorEntity(client, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
+            TempSensorEntity(client, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
+
+            VoltSensorEntity(client, "bmsMaster.vol", const.BATTERY_VOLT, False),
+            AmpSensorEntity(client, "bmsMaster.amp", const.BATTERY_AMP, False),
+            VoltSensorEntity(client, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
+            VoltSensorEntity(client, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
 
             CyclesSensorEntity(client, "bmsMaster.cycles", const.CYCLES),
+
+
+            # Secondary battery
+            LevelSensorEntity(client, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL),
+            CyclesSensorEntity(client, "bmsSlave1.cycles", const.SLAVE_CYCLES),
+            TempSensorEntity(client, "bmsSlave1.temp", const.SLAVE_BATTERY_TEMP),
+            VoltSensorEntity(client, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False),
+            AmpSensorEntity(client, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
+            VoltSensorEntity(client, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
+            VoltSensorEntity(client, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
+
+
             StatusSensorEntity(client),
 
         ]


### PR DESCRIPTION
River Pro:
- Add support for secondary battery
- Expose bms current / volt to monitor charging direction