### PR TITLE
divide mppt.outWatts by 10 for Delta Pro

### DIFF
--- a/custom_components/ecoflow_cloud/devices/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/delta2.py
@@ -5,7 +5,7 @@ from ..number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevel
     MaxGenStopLevelEntity, MinGenStartLevelEntity
 from ..select import DictSelectEntity, TimeoutDictSelectEntity
 from ..sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, QuotasStatusSensorEntity
+    InWattsSensorEntity, OutWattsSensorEntity, OutWattsDcSensorEntity, VoltSensorEntity, QuotasStatusSensorEntity
 from ..switch import BeeperEntity, EnabledEntity
 
 
@@ -24,8 +24,8 @@ class Delta2(BaseDevice):
 
             # OutWattsSensorEntity(client, "pd.carWatts", const.DC_OUT_POWER),
             # the same value as pd.carWatts
-            OutWattsSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
-
+            OutWattsDcSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
+            
             OutWattsSensorEntity(client, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
             OutWattsSensorEntity(client, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
 

--- a/custom_components/ecoflow_cloud/devices/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/delta2.py
@@ -5,7 +5,7 @@ from ..number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevel
     MaxGenStopLevelEntity, MinGenStartLevelEntity
 from ..select import DictSelectEntity, TimeoutDictSelectEntity
 from ..sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, OutWattsDcSensorEntity, VoltSensorEntity, QuotasStatusSensorEntity
+    InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, QuotasStatusSensorEntity
 from ..switch import BeeperEntity, EnabledEntity
 
 
@@ -24,7 +24,7 @@ class Delta2(BaseDevice):
 
             # OutWattsSensorEntity(client, "pd.carWatts", const.DC_OUT_POWER),
             # the same value as pd.carWatts
-            OutWattsDcSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
+            OutWattsSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
             
             OutWattsSensorEntity(client, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
             OutWattsSensorEntity(client, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),

--- a/custom_components/ecoflow_cloud/devices/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/delta2.py
@@ -25,7 +25,7 @@ class Delta2(BaseDevice):
             # OutWattsSensorEntity(client, "pd.carWatts", const.DC_OUT_POWER),
             # the same value as pd.carWatts
             OutWattsSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
-            
+
             OutWattsSensorEntity(client, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
             OutWattsSensorEntity(client, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
 

--- a/custom_components/ecoflow_cloud/devices/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/delta_pro.py
@@ -5,7 +5,7 @@ from ..number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevel
     MaxGenStopLevelEntity
 from ..select import DictSelectEntity, TimeoutDictSelectEntity
 from ..sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InWattsSolarSensorEntity, \
+    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, OutWattsDcSensorEntity, VoltSensorEntity, InWattsSolarSensorEntity, \
     StatusSensorEntity, InEnergySensorEntity, OutEnergySensorEntity
 from ..switch import BeeperEntity, EnabledEntity
 
@@ -21,7 +21,7 @@ class DeltaPro(BaseDevice):
             InWattsSolarSensorEntity(client, "mppt.inWatts", const.SOLAR_IN_POWER),
 
             OutWattsSensorEntity(client, "inv.outputWatts", const.AC_OUT_POWER),
-            OutWattsSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
+            OutWattsDcSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
             # OutWattsSensorEntity(client, "pd.carWatts", const.DC_OUT_POWER),
 
             OutWattsSensorEntity(client, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -149,7 +149,11 @@ class InWattsSolarSensorEntity(InWattsSensorEntity):
 class OutWattsSensorEntity(WattsSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"
 
-
+class OutWattsDcSensorEntity(WattsSensorEntity):
+    _attr_icon = "mdi:transmission-tower-export"
+    def _update_value(self, val: Any) -> bool:
+        return super()._update_value(int(val) / 10)
+    
 class InVoltSensorEntity(VoltSensorEntity):
     _attr_icon = "mdi:transmission-tower-import"
 


### PR DESCRIPTION
The data from `mppt.outWatts`  for the Delta Pro seems to be in 1/10 watt, as shown by the graph below:
<img width="1082" alt="Screenshot 2023-07-19 at 1 35 31 AM" src="https://github.com/tolwi/hassio-ecoflow-cloud/assets/1226173/8bb32ef1-3655-4991-9182-99e903dbbc3a">

I have a 400W solar panel attached, so its definitely not outputting over 3kW of power DC.