### PR TITLE
Support PowerStream Messages with Multiple Payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,8 +482,20 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> POWERSTREAM <i>(sensors: 25, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> POWERSTREAM <sup>beta</sup> <i>(sensors: 55, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
+
+Due to limitations with the way that Ecoflow have implemented the communication
+between the device and app only a couple of fields at a time get updated. It may
+take several hours for all fields to receive data. However, launching the app
+and viewing the PowerStream should force all the fields to be updated at once.
+
+PowerStream support is still in development.
+
+Wishlist
+
+- Ability to change settings
+- Add Sensors to allow data to be displyed on the Energy Dashboard
 
 *Sensors*
 - Solar 1 Watts

--- a/custom_components/ecoflow_cloud/devices/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/powerstream.py
@@ -35,7 +35,7 @@ class PowerStream(BaseDevice):
             MiscSensorEntity(client, "pv2_warning_code", "Solar 2 Warning Code", False),
             MiscSensorEntity(client, "pv2_status", "Solar 2 Status", False),
 
-            MiscSensorEntity(client, "bpType", "Battery Type", False),
+            MiscSensorEntity(client, "bp_type", "Battery Type", False),
             LevelSensorEntity(client, "bat_soc", "Battery Charge"),
             DeciwattsSensorEntity(client, "bat_input_watts", "Battery Input Watts"),
             DecivoltSensorEntity(client, "bat_input_volt", "Battery Input Potential"),


### PR DESCRIPTION
When the Ecoflow app is launched it requests a full package of data. Previously it wasn't visible because 2 payloads were sent in 1 MQTT message and couldn't be read. This change adds support for multiple payloads being sent in a single MQTT message. This means that the integration can get all of the sensor data when the user opens the Ecoflow app and views the PowerStream.

I have also added some notes to the ReadMe explaining that support for PowerStream is still being worked on and the limitations imposed by Ecoflow about how frequently data is updated although this PR should help with that.