### PR TITLE
fixed the enable/disable for Power Reserve on Delta Pro

### DIFF
--- a/custom_components/ecoflow_cloud/devices/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/delta_pro.py
@@ -126,8 +126,11 @@ class DeltaPro(BaseDevice):
 
             EnabledEntity(client, "inv.acPassByAutoEn", const.AC_ALWAYS_ENABLED,
                           lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 84, "enabled": value}}),
-            EnabledEntity(client, "pd.bpPowerSoc", const.BP_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"isConfig": value}}),
+            EnabledEntity(client, "pd.bppowerSoc", const.BP_ENABLED,
+                          lambda value, params: {"moduleType": 0, "operateType": "TCP", "params": {"id": 94, "isConfig": value, 
+                                                            "bpPowerSoc": int(params["pd.bppowerSoc"]),
+                                                            "minDsgSoc": 0,
+                                                            "maxChgSoc": 0}}),
         ]
 
     def selects(self, client: EcoflowMQTTClient) -> list[BaseSelectEntity]:


### PR DESCRIPTION
the case change on `pd.bppowerSoc` is intentional.  For some reason the data coming in changed to that...  However, the `params` value is still `bpPowerSoc`.  