### PR TITLE
Extend DC_CHARGE_CURRENT_OPTIONS with 0 (Zero) Value

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -63,6 +63,7 @@ DC_TIMEOUT_OPTIONS = {
 }
 
 DC_CHARGE_CURRENT_OPTIONS = {
+    "0A": 0,
     "4A": 4000,
     "6A": 6000,
     "8A": 8000


### PR DESCRIPTION
Method def _update_value from Class DictSelectEntity crash on mppt.cfgDcChgCurrent : 0

**Trace:** 
`023-08-07 11:27:39.638 ERROR (Thread-2 (_thread_main)) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 3591, in _thread_main
    self.loop_forever(retry_first_connection=True)
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 1756, in loop_forever
    rc = self._loop(timeout)
         ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 1164, in _loop
    rc = self.loop_read()
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 1556, in loop_read
    rc = self._packet_read()
         ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 2439, in _packet_read
    rc = self._packet_handle()
         ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 3033, in _packet_handle
    return self._handle_publish()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 3327, in _handle_publish
    self._handle_on_message(message)
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 3570, in _handle_on_message
    on_message(self, self._userdata, message)
  File "/config/custom_components/ecoflow_cloud/mqtt/ecoflow_mqtt.py", line 248, in on_json_message
    self.data.update_data(raw)
  File "/config/custom_components/ecoflow_cloud/mqtt/ecoflow_mqtt.py", line 153, in update_data
    self.__broadcast()
  File "/config/custom_components/ecoflow_cloud/mqtt/ecoflow_mqtt.py", line 157, in __broadcast
    self.__params_observable.on_next(self.params)
  File "/usr/local/lib/python3.11/site-packages/reactivex/subject/subject.py", line 59, in on_next
    super().on_next(value)
  File "/usr/local/lib/python3.11/site-packages/reactivex/observer/observer.py", line 39, in on_next
    self._on_next_core(value)
  File "/usr/local/lib/python3.11/site-packages/reactivex/subject/subject.py", line 66, in _on_next_core
    observer.on_next(value)
  File "/usr/local/lib/python3.11/site-packages/reactivex/observer/autodetachobserver.py", line 28, in on_next
    self._on_next(value)
  File "/config/custom_components/ecoflow_cloud/entities/__init__.py", line 82, in _updated
    if self._update_value(data[self._mqtt_key]):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/ecoflow_cloud/select.py", line 41, in _update_value
    self._attr_current_option = lval[0]
                                ~~~~^^^
IndexError: list index out of range`

**Data from MQTT Response:**
![image](https://github.com/tolwi/hassio-ecoflow-cloud/assets/23555868/7810e431-c6fd-4f5a-b42c-83df8527ac27)
