### PR TITLE
DELTA_2_MAX: Add missing Backup Reserve configuration for Delta 2 Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,10 +638,12 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - AC Enabled 
 - X-Boost Enabled 
 - DC (12V) Enabled 
+- Backup Reserve Enabled 
 
 *Sliders (numbers)*
 - Max Charge Level 
 - Min Discharge Level 
+- Backup Reserve Level 
 - Generator Auto Start Level 
 - Generator Auto Stop Level 
 - AC Charging Power 

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> DELTA_2_MAX <i>(sensors: 60, switches: 6, sliders: 5, selects: 3)</i> </summary>
+<details><summary> DELTA_2_MAX <i>(sensors: 60, switches: 7, sliders: 6, selects: 3)</i> </summary>
 <p>
 
 *Sensors*

--- a/custom_components/ecoflow_cloud/devices/delta2_max.py
+++ b/custom_components/ecoflow_cloud/devices/delta2_max.py
@@ -4,7 +4,7 @@ from . import const, BaseDevice, EntityMigration, MigrationAction
 from .. import EcoflowMQTTClient
 from ..entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
 from ..number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevelEntity, \
-    MaxGenStopLevelEntity, MinGenStartLevelEntity
+    MaxGenStopLevelEntity, MinGenStartLevelEntity, BatteryBackupLevel
 from ..select import TimeoutDictSelectEntity
 from ..sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, CyclesSensorEntity, \
     InWattsSensorEntity, OutWattsSensorEntity, StatusSensorEntity, MilliVoltSensorEntity, \
@@ -138,6 +138,12 @@ class Delta2Max(BaseDevice):
                                                  "moduleSn": client.device_sn,
                                                  "params": {"minDsgSoc": int(value)}}),
 
+            BatteryBackupLevel(client, "pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
+                               "bms_emsStatus.minDsgSoc", "bms_emsStatus.maxChargeSoc",
+                               lambda value: {"moduleType": 1, "operateType": "watthConfig",
+                                              "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0,
+                                                         "minChgSoc": 0}}),
+
             MinGenStartLevelEntity(client, "bms_emsStatus.minOpenOilEbSoc", const.GEN_AUTO_START_LEVEL, 0, 30,
                                    lambda value: {"moduleType": 2, "operateType": "closeOilSoc",
                                                   "moduleSn": client.device_sn,
@@ -185,7 +191,15 @@ class Delta2Max(BaseDevice):
                                          "params": {"xboost": value}}),
             EnabledEntity(client, "pd.carState", const.DC_ENABLED,
                           lambda value: {"moduleType": 5, "operateType": "mpptCar",
-                                         "params": {"enabled": value}})
+                                         "params": {"enabled": value}}),
+
+            EnabledEntity(client, "pd.bpPowerSoc", const.BP_ENABLED,
+                          lambda value: {"moduleType": 1,
+                                         "operateType": "watthConfig",
+                                         "params": {"bpPowerSoc": value,
+                                                    "minChgSoc": 0,
+                                                    "isConfig": value,
+                                                    "minDsgSoc": 0}}),
         ]
 
     def selects(self, client: EcoflowMQTTClient) -> list[BaseSelectEntity]:

--- a/docs/devices/DELTA_2_MAX.md
+++ b/docs/devices/DELTA_2_MAX.md
@@ -69,10 +69,12 @@
 - AC Enabled (`inv.cfgAcEnabled` -> `{"moduleType": 3, "operateType": "acOutCfg", "moduleSn": "MOCK", "params": {"enabled": "VALUE", "out_voltage": -1, "out_freq": 255, "xboost": 255}}`)
 - X-Boost Enabled (`inv.cfgAcXboost` -> `{"moduleType": 3, "operateType": "acOutCfg", "moduleSn": "MOCK", "params": {"xboost": "VALUE"}}`)
 - DC (12V) Enabled (`pd.carState` -> `{"moduleType": 5, "operateType": "mpptCar", "params": {"enabled": "VALUE"}}`)
+- Backup Reserve Enabled (`pd.bpPowerSoc` -> `{"moduleType": 1, "operateType": "watthConfig", "params": {"bpPowerSoc": "VALUE", "minChgSoc": 0, "isConfig": "VALUE", "minDsgSoc": 0}}`)
 
 *Sliders (numbers)*
 - Max Charge Level (`bms_emsStatus.maxChargeSoc` -> `{"moduleType": 2, "operateType": "upsConfig", "moduleSn": "MOCK", "params": {"maxChgSoc": "VALUE"}}` [50 - 100])
 - Min Discharge Level (`bms_emsStatus.minDsgSoc` -> `{"moduleType": 2, "operateType": "dsgCfg", "moduleSn": "MOCK", "params": {"minDsgSoc": "VALUE"}}` [0 - 30])
+- Backup Reserve Level (`pd.bpPowerSoc` -> `{"moduleType": 1, "operateType": "watthConfig", "params": {"isConfig": 1, "bpPowerSoc": "VALUE", "minDsgSoc": 0, "minChgSoc": 0}}` [5 - 100])
 - Generator Auto Start Level (`bms_emsStatus.minOpenOilEbSoc` -> `{"moduleType": 2, "operateType": "closeOilSoc", "moduleSn": "MOCK", "params": {"closeOilSoc": "VALUE"}}` [0 - 30])
 - Generator Auto Stop Level (`bms_emsStatus.maxCloseOilEbSoc` -> `{"moduleType": 2, "operateType": "openOilSoc", "moduleSn": "MOCK", "params": {"openOilSoc": "VALUE"}}` [50 - 100])
 - AC Charging Power (`inv.SlowChgWatts` -> `{"moduleType": 3, "operateType": "acChgCfg", "moduleSn": "MOCK", "params": {"slowChgWatts": "VALUE", "fastChgWatts": 255, "chgPauseFlag": 0}}` [200 - 2400])


### PR DESCRIPTION
Copied [Delta 2 config](https://github.com/tolwi/hassio-ecoflow-cloud/blob/e7dc53e7fa4432d9c761289630d52a8fdd4f51ee/custom_components/ecoflow_cloud/devices/delta2.py) to [Delta 2 Max](https://github.com/tolwi/hassio-ecoflow-cloud/blob/e7dc53e7fa4432d9c761289630d52a8fdd4f51ee/custom_components/ecoflow_cloud/devices/delta2_max.py) and it appears to be working. This PR adds:
- “Backup Reserve Enabled” Switch
- “Backup Reserve Level” Slider

Closes tolwi#179 feature request.