### PR TITLE
Add device model name

### DIFF
--- a/custom_components/ecoflow_cloud/mqtt/ecoflow_mqtt.py
+++ b/custom_components/ecoflow_cloud/mqtt/ecoflow_mqtt.py
@@ -185,6 +185,7 @@ class EcoflowMQTTClient:
             identifiers={(DOMAIN, self.device_sn)},
             manufacturer="EcoFlow",
             name=entry.title,
+            model=self.device_type,
         )
 
         self.client = mqtt_client.Client(client_id=f'ANDROID_-{str(uuid.uuid4()).upper()}_{auth.user_id}',


### PR DESCRIPTION
Extremely minor update, but it bugged me that the model name was empty when viewing the devices tab