### PR TITLE
correct DC_CAR_OUT_POWER scaling and AC_CHARGING_POWER for Delta Mini

### DIFF
--- a/custom_components/ecoflow_cloud/devices/delta_mini.py
+++ b/custom_components/ecoflow_cloud/devices/delta_mini.py
@@ -40,7 +40,7 @@ class DeltaMini(BaseDevice):
 
             OutWattsDcSensorEntity(client, "mppt.outWatts", const.DC_OUT_POWER),
 
-            OutWattsSensorEntity(client, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
+            OutWattsDcSensorEntity(client, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
             OutWattsSensorEntity(client, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
 
             OutWattsSensorEntity(client, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
@@ -93,7 +93,7 @@ class DeltaMini(BaseDevice):
             #                       lambda value: {"moduleType": 0, "operateType": "TCP",
             #                                      "params": {"closeOilSoc": value, "id": 53}}),
 
-            ChargingPowerEntity(client, "inv.cfgSlowChgWatts", const.AC_CHARGING_POWER, 200, 2900,
+            ChargingPowerEntity(client, "inv.cfgSlowChgWatts", const.AC_CHARGING_POWER, 200, 900,
                                 lambda value: {"moduleType": 0, "operateType": "TCP",
                                                "params": {"slowChgPower": value, "id": 69}}),
 


### PR DESCRIPTION
correction for these two fields for Delta Mini

1. DC_CAR_OUT_POWER scaling (/10)

1. AC_CHARGING_POWER (900W)

<img width="1418" alt="Screenshot 2024-05-12 at 12 02 18" src="https://github.com/tolwi/hassio-ecoflow-cloud/assets/3071609/057fad6a-209a-462c-889d-021c3f59ca9e">
