### PR TITLE
River Max: Add "Auto Fan Speed" switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> RIVER_MAX <i>(sensors: 40, switches: 4, sliders: 1, selects: 2)</i> </summary>
+<details><summary> RIVER_MAX <i>(sensors: 40, switches: 5, sliders: 1, selects: 2)</i> </summary>
 <p>
 
 *Sensors*
@@ -412,6 +412,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - AC Enabled 
 - DC (12V) Enabled 
 - X-Boost Enabled 
+- Auto Fan Speed 
 
 *Sliders (numbers)*
 - Max Charge Level  _(read-only)_

--- a/custom_components/ecoflow_cloud/devices/internal/river_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_max.py
@@ -7,7 +7,7 @@ from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSenso
     CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, StatusSensorEntity, \
     InEnergySensorEntity, OutEnergySensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
     OutMilliVoltSensorEntity, CapacitySensorEntity
-from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity
+from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity, FanModeEntity
 
 
 class RiverMax(BaseDevice):
@@ -95,8 +95,8 @@ class RiverMax(BaseDevice):
             BeeperEntity(client, "pd.beepState", const.BEEPER, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 38, "enabled": value}}),
             EnabledEntity(client, "inv.cfgAcEnabled", const.AC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "enabled": value}}),
             EnabledEntity(client, "pd.carSwitch", const.DC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 34, "enabled": value}}),
-            EnabledEntity(client, "inv.cfgAcXboost", const.XBOOST_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}})
-
+            EnabledEntity(client, "inv.cfgAcXboost", const.XBOOST_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
+            FanModeEntity(client, "inv.cfgFanMode", const.AUTO_FAN_SPEED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 73, "fanMode": value}})
         ]
     
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:

--- a/custom_components/ecoflow_cloud/switch.py
+++ b/custom_components/ecoflow_cloud/switch.py
@@ -50,6 +50,22 @@ class DisabledEntity(BaseSwitchEntity):
             self.send_set_message(1, self.command_dict(1))
 
 
+class FanModeEntity(BaseSwitchEntity):  # for River Max
+
+    def _update_value(self, val: Any) -> bool:
+        _LOGGER.debug("Updating switch " + self._attr_unique_id + " to " + str(val))
+        self._attr_is_on = val == 1
+        return True
+
+    def turn_on(self, **kwargs: Any) -> None:
+        if self._command:
+            self.send_set_message(1, self.command_dict(1))
+
+    def turn_off(self, **kwargs: Any) -> None:
+        if self._command:
+            self.send_set_message(3, self.command_dict(3))
+
+
 class BeeperEntity(DisabledEntity):
     _attr_entity_category = EntityCategory.CONFIG
 

--- a/docs/devices/RIVER_MAX.md
+++ b/docs/devices/RIVER_MAX.md
@@ -47,6 +47,7 @@
 - AC Enabled (`inv.cfgAcEnabled` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "enabled": "VALUE"}}`)
 - DC (12V) Enabled (`pd.carSwitch` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 34, "enabled": "VALUE"}}`)
 - X-Boost Enabled (`inv.cfgAcXboost` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": "VALUE"}}`)
+- Auto Fan Speed (`inv.cfgFanMode` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 73, "fanMode": "VALUE"}}`)
 
 *Sliders (numbers)*
 - Max Charge Level (`bmsMaster.maxChargeSoc` -> `_ command not available _` [30 - 100])


### PR DESCRIPTION
Tested on my River Max, firmware versions: V1.2.4.23, V3.0.1.11 (Wi-Fi).

Created new switch entity "FanModeEntity" because River Max excepts "1" to enable and "3" to disable (reverse engineered and debugged with MQTTX), so cannot reuse same entity from River Pro.