### PR TITLE
Fix a little typo in powerstream.py

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -92,7 +92,7 @@ class PowerStream(BaseDevice):
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
             # These will likely be some form of serialised data rather than JSON will look into it later
-            # MinBatteryLevelEntity(client, self,  "lowerLimit", "Min Disharge Level", 50, 100,
+            # MinBatteryLevelEntity(client, self,  "lowerLimit", "Min Discharge Level", 50, 100,
             #                       lambda value: {"moduleType": 0, "operateType": "TCP",
             #                                      "params": {"id": 00, "lowerLimit": value}}),
             # MaxBatteryLevelEntity(client, self,  "upperLimit", "Max Charge Level", 0, 30,


### PR DESCRIPTION
Corrected typo "disharge" to "discharge" in commented code