### PR TITLE
fix: AC Charging power for Delta Max

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_max.py
@@ -96,7 +96,7 @@ class DeltaMax(BaseDevice):
                                   lambda value: {"moduleType": 2, "operateType": "TCP",
                                                  "params": {"id": 53, "closeOilSoc": value}}),
 
-            ChargingPowerEntity(client, self, "inv.cfgFastChgWatt", const.AC_CHARGING_POWER, 200, 2000,
+            ChargingPowerEntity(client, self, "inv.cfgSlowChgWatts", const.AC_CHARGING_POWER, 100, 2000,
                                 lambda value: {"moduleType": 0, "operateType": "TCP",
                                                "params": {"slowChgPower": value, "id": 69}}),
 


### PR DESCRIPTION
Hi, I fixed name and min value of parameter "AC Charging Power" for Delta Max version