### PR TITLE
Cleanup and standardization of older river and delta v1 units.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Battery Level (Precise)  _(disabled)_
 - Total In Power
 - Total Out Power
-- Main Battery Current
 - AC In Power
 - AC Out Power
 - AC In Volts
@@ -300,6 +299,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Battery Temperature
 - Min Cell Temperature  _(disabled)_
 - Max Cell Temperature  _(disabled)_
+- Main Battery Current  _(disabled)_
 - Battery Volts  _(disabled)_
 - Min Cell Volts  _(disabled)_
 - Max Cell Volts  _(disabled)_
@@ -362,7 +362,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> RIVER_MAX <i>(sensors: 40, switches: 5, sliders: 1, selects: 2)</i> </summary>
+<details><summary> RIVER_MAX <i>(sensors: 49, switches: 5, sliders: 1, selects: 3)</i> </summary>
 <p>
 
 *Sensors*
@@ -370,67 +370,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_
 - Main Remain Capacity  _(disabled)_
-- Total In Power
-- Total Out Power
-- AC In Power
-- AC Out Power
-- AC In Volts
-- AC Out Volts
-- DC Out Power
-- Type-C Out Power
-- USB (1) Out Power
-- USB (2) Out Power
-- USB (3) Out Power
-- Remaining Time
-- Cycles
-- Battery Temperature
-- Min Cell Temperature  _(disabled)_
-- Max Cell Temperature  _(disabled)_
-- Battery Volts  _(disabled)_
-- Min Cell Volts  _(disabled)_
-- Max Cell Volts  _(disabled)_
-- Solar In Energy
-- Battery Charge Energy from AC
-- Battery Charge Energy from DC
-- Battery Discharge Energy to AC
-- Battery Discharge Energy to DC
-- Slave Battery Level  _(auto)_
-- Slave Design Capacity  _(disabled)_
-- Slave Full Capacity  _(disabled)_
-- Slave Remain Capacity  _(disabled)_
-- Slave Battery Temperature  _(auto)_
-- Slave Min Cell Temperature  _(disabled)_
-- Slave Max Cell Temperature  _(disabled)_
-- Battery Volts  _(disabled)_
-- Min Cell Volts  _(disabled)_
-- Max Cell Volts  _(disabled)_
-- Slave Cycles  _(auto)_
-- Status
-
-*Switches*
-- Beeper 
-- AC Enabled 
-- DC (12V) Enabled 
-- X-Boost Enabled 
-- Auto Fan Speed 
-
-*Sliders (numbers)*
-- Max Charge Level  _(read-only)_
-
-*Selects*
-- Unit Timeout 
-- AC Timeout 
-
-</p></details>
-
-<details><summary> RIVER_PRO <i>(sensors: 46, switches: 7, sliders: 1, selects: 3)</i> </summary>
-<p>
-
-*Sensors*
-- Main Battery Level
-- Main Design Capacity  _(disabled)_
-- Main Full Capacity  _(disabled)_
-- Main Remain Capacity  _(disabled)_
+- Battery Level
 - Total In Power
 - Total Out Power
 - Solar In Current
@@ -447,9 +387,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - USB (2) Out Power
 - USB (3) Out Power
 - Remaining Time
+- Cycles
 - Battery Temperature
 - Min Cell Temperature  _(disabled)_
 - Max Cell Temperature  _(disabled)_
+- Battery Current  _(disabled)_
+- Battery Volts  _(disabled)_
+- Min Cell Volts  _(disabled)_
+- Max Cell Volts  _(disabled)_
 - Inverter Inside Temperature
 - Inverter Outside Temperature
 - Solar In Energy
@@ -457,21 +402,89 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Battery Charge Energy from DC
 - Battery Discharge Energy to AC
 - Battery Discharge Energy to DC
-- Battery Current  _(disabled)_
-- Battery Volts  _(disabled)_
-- Min Cell Volts  _(disabled)_
-- Max Cell Volts  _(disabled)_
-- Cycles
 - Slave Battery Level  _(auto)_
 - Slave Design Capacity  _(disabled)_
 - Slave Full Capacity  _(disabled)_
 - Slave Remain Capacity  _(disabled)_
-- Slave Cycles  _(auto)_
 - Slave Battery Temperature  _(auto)_
+- Slave Min Cell Temperature  _(disabled)_
+- Slave Max Cell Temperature  _(disabled)_
 - Slave Battery Current  _(disabled)_
 - Slave Battery Volts  _(disabled)_
 - Slave Min Cell Volts  _(disabled)_
 - Slave Max Cell Volts  _(disabled)_
+- Slave Cycles  _(auto)_
+- Status
+
+*Switches*
+- Beeper 
+- AC Enabled 
+- DC (12V) Enabled 
+- X-Boost Enabled 
+- Auto Fan Speed 
+
+*Sliders (numbers)*
+- Max Charge Level 
+
+*Selects*
+- Unit Timeout 
+- DC (12V) Timeout 
+- AC Timeout 
+
+</p></details>
+
+<details><summary> RIVER_PRO <i>(sensors: 49, switches: 7, sliders: 1, selects: 3)</i> </summary>
+<p>
+
+*Sensors*
+- Main Battery Level
+- Main Design Capacity  _(disabled)_
+- Main Full Capacity  _(disabled)_
+- Main Remain Capacity  _(disabled)_
+- Battery Level
+- Total In Power
+- Total Out Power
+- Solar In Current
+- Solar In Voltage
+- AC In Power
+- AC Out Power
+- AC In Volts
+- AC Out Volts
+- DC Out Power
+- Type-C Out Power
+- DC Temperature  _(disabled)_
+- USB C Temperature  _(disabled)_
+- USB (1) Out Power
+- USB (2) Out Power
+- USB (3) Out Power
+- Remaining Time
+- Cycles
+- Battery Temperature
+- Min Cell Temperature  _(disabled)_
+- Max Cell Temperature  _(disabled)_
+- Battery Current  _(disabled)_
+- Battery Volts  _(disabled)_
+- Min Cell Volts  _(disabled)_
+- Max Cell Volts  _(disabled)_
+- Inverter Inside Temperature
+- Inverter Outside Temperature
+- Solar In Energy
+- Battery Charge Energy from AC
+- Battery Charge Energy from DC
+- Battery Discharge Energy to AC
+- Battery Discharge Energy to DC
+- Slave Battery Level  _(auto)_
+- Slave Design Capacity  _(disabled)_
+- Slave Full Capacity  _(disabled)_
+- Slave Remain Capacity  _(disabled)_
+- Slave Battery Temperature  _(auto)_
+- Slave Min Cell Temperature  _(disabled)_
+- Slave Max Cell Temperature  _(disabled)_
+- Slave Battery Current  _(disabled)_
+- Slave Battery Volts  _(disabled)_
+- Slave Min Cell Volts  _(disabled)_
+- Slave Max Cell Volts  _(disabled)_
+- Slave Cycles  _(auto)_
 - Status
 
 *Switches*
@@ -484,7 +497,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Auto Fan Speed 
 
 *Sliders (numbers)*
-- Max Charge Level 
+- Max Charge Level  _(read-only)_
 
 *Selects*
 - Unit Timeout 
@@ -526,16 +539,18 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> DELTA_MINI <i>(sensors: 33, switches: 4, sliders: 3, selects: 4)</i> </summary>
+<details><summary> DELTA_MINI <i>(sensors: 39, switches: 4, sliders: 3, selects: 4)</i> </summary>
 <p>
 
 *Sensors*
 - Main Battery Level
+- Main Battery Level (Precise)  _(disabled)_
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_
 - Main Remain Capacity  _(disabled)_
 - State of Health
 - Battery Level
+- Battery Level (Precise)  _(disabled)_
 - Total In Power
 - Total Out Power
 - AC In Power
@@ -543,7 +558,10 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - AC In Volts
 - AC Out Volts
 - Solar In Power
+- Solar In Voltage
+- Solar In Current
 - DC Out Power
+- DC Out Voltage
 - DC Car Out Power
 - DC Anderson Out Power
 - Type-C (1) Out Power
@@ -556,6 +574,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Discharge Remaining Time
 - Cycles
 - Battery Temperature  _(disabled)_
+- Main Battery Current  _(disabled)_
 - Battery Volts  _(disabled)_
 - Solar In Energy
 - Battery Charge Energy from AC
@@ -583,23 +602,30 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> DELTA_MAX <i>(sensors: 30, switches: 7, sliders: 5, selects: 0)</i> </summary>
+<details><summary> DELTA_MAX <i>(sensors: 70, switches: 7, sliders: 5, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
 - Main Battery Level
+- Main Battery Level (Precise)  _(disabled)_
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_
 - Main Remain Capacity  _(disabled)_
+- State of Health
 - Battery Level
+- Battery Level (Precise)  _(disabled)_
 - Total In Power
 - Total Out Power
+- Main Battery Current
 - AC In Power
 - AC Out Power
 - AC In Volts
 - AC Out Volts
 - Solar In Power
+- Solar In Voltage
+- Solar In Current
 - DC Out Power
+- DC Out Voltage
 - Type-C (1) Out Power
 - Type-C (2) Out Power
 - USB (1) Out Power
@@ -616,6 +642,39 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Battery Volts  _(disabled)_
 - Min Cell Volts  _(disabled)_
 - Max Cell Volts  _(disabled)_
+- Solar In Energy
+- Battery Charge Energy from AC
+- Battery Charge Energy from DC
+- Battery Discharge Energy to AC
+- Battery Discharge Energy to DC
+- Slave 1 Battery Level  _(auto)_
+- Slave 1 Battery Level (Precise)  _(disabled)_
+- Slave 1 Design Capacity  _(disabled)_
+- Slave 1 Full Capacity  _(disabled)_
+- Slave 1 Remain Capacity  _(disabled)_
+- Slave 1 State of Health
+- Slave 1 Battery Temperature  _(auto)_
+- Slave 1 In Power  _(auto)_
+- Slave 1 Out Power  _(auto)_
+- Slave 2 Battery Level  _(auto)_
+- Slave 2 Battery Level (Precise)  _(disabled)_
+- Slave 2 Design Capacity  _(disabled)_
+- Slave 2 Full Capacity  _(disabled)_
+- Slave 2 Remain Capacity  _(disabled)_
+- Slave 2 State of Health
+- Slave 1 Battery Volts  _(disabled)_
+- Slave 1 Min Cell Volts  _(disabled)_
+- Slave 1 Max Cell Volts  _(disabled)_
+- Slave 1 Battery Current  _(disabled)_
+- Slave 2 Battery Volts  _(disabled)_
+- Slave 2 Min Cell Volts  _(disabled)_
+- Slave 2 Max Cell Volts  _(disabled)_
+- Slave 2 Battery Current  _(disabled)_
+- Slave 2 Battery Temperature  _(auto)_
+- Slave 2 In Power  _(auto)_
+- Slave 2 Out Power  _(auto)_
+- Slave 1 Cycles  _(disabled)_
+- Slave 2 Cycles  _(disabled)_
 - Status
 
 *Switches*

--- a/custom_components/ecoflow_cloud/devices/internal/delta_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_max.py
@@ -3,11 +3,12 @@ from custom_components.ecoflow_cloud.devices import const, BaseDevice
 from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
 from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevelEntity, \
     MaxGenStopLevelEntity, MinGenStartLevelEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
+from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
     CyclesSensorEntity, \
     InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
     InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
-    OutWattsDcSensorEntity, QuotaStatusSensorEntity
+    InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
+    AmpSensorEntity, InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -18,13 +19,21 @@ class DeltaMax(BaseDevice):
                 .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
                 .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
                 .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(client, self, "bmsMaster.f32ShowSoc", const.MAIN_BATTERY_LEVEL_F32, False)
+                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
 
+            LevelSensorEntity(client, self, "bmsMaster.soh", const.SOH),
+
             LevelSensorEntity(client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
+            LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
+            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
@@ -33,7 +42,11 @@ class DeltaMax(BaseDevice):
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
 
             InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
+            InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
+            InAmpSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
+
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
+            OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
 
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
@@ -62,19 +75,60 @@ class DeltaMax(BaseDevice):
             MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
 
-            # Optional Slave Battery
-            #LevelSensorEntity(client, self, "bms_slave.soc", const.SLAVE_BATTERY_LEVEL, False, True),
-            #TempSensorEntity(client, self, "bms_slave.temp", const.SLAVE_BATTERY_TEMP, False, True),
-            #TempSensorEntity(client, self, "bms_slave.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
-            #TempSensorEntity(client, self, "bms_slave.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
+            # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
+            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
+            InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
+            OutEnergySensorEntity(client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY),
+            OutEnergySensorEntity(client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY),
 
-            #VoltSensorEntity(client, self, "bms_slave.vol", const.SLAVE_BATTERY_VOLT, False),
-            #VoltSensorEntity(client, self, "bms_slave.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
-            #VoltSensorEntity(client, self, "bms_slave.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
+            # Optional Slave Batteries
+            LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_N_BATTERY_LEVEL % 1, False, True)
+                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(client, self, "bmsSlave1.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 1, False, False)
+                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_N_DESIGN_CAPACITY % 1, False),
+            CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_N_FULL_CAPACITY % 1, False),
+            CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 1, False),
+            LevelSensorEntity(client, self, "bmsSlave1.soh", const.SLAVE_N_SOH % 1),
 
-            #CyclesSensorEntity(client, self, "bms_slave.cycles", const.SLAVE_CYCLES, False, True),
-            #InWattsSensorEntity(client, self, "bms_slave.inputWatts", const.SLAVE_IN_POWER, False, True),
-            #OutWattsSensorEntity(client, self, "bms_slave.outputWatts", const.SLAVE_OUT_POWER, False, True)
+            TempSensorEntity(client, self, "bmsSlave1.temp", const.SLAVE_N_BATTERY_TEMP % 1, False, True)
+            .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            WattsSensorEntity(client, self, "bmsSlave1.inputWatts", const.SLAVE_N_IN_POWER % 1, False, True),
+            WattsSensorEntity(client, self, "bmsSlave1.outputWatts", const.SLAVE_N_OUT_POWER % 1, False, True),
+
+            LevelSensorEntity(client, self, "bmsSlave2.soc", const.SLAVE_N_BATTERY_LEVEL % 2, False, True)
+                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(client, self, "bmsSlave2.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 2, False, False)
+                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(client, self, "bmsSlave2.designCap", const.SLAVE_N_DESIGN_CAPACITY % 2, False),
+            CapacitySensorEntity(client, self, "bmsSlave2.fullCap", const.SLAVE_N_FULL_CAPACITY % 2, False),
+            CapacitySensorEntity(client, self, "bmsSlave2.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 2, False),
+            LevelSensorEntity(client, self, "bmsSlave2.soh", const.SLAVE_N_SOH % 2),
+            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 1, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 1, False),
+            AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave2.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 2, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
+            AmpSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
+            TempSensorEntity(client, self, "bmsSlave2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
+                .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+                .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            WattsSensorEntity(client, self, "bmsSlave2.inputWatts", const.SLAVE_N_IN_POWER % 2, False, True),
+            WattsSensorEntity(client, self, "bmsSlave2.outputWatts", const.SLAVE_N_OUT_POWER % 2, False, True),
+            CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_N_CYCLES % 1, False),
+            CyclesSensorEntity(client, self, "bmsSlave2.cycles", const.SLAVE_N_CYCLES % 2, False),
             QuotaStatusSensorEntity(client, self)
         ]
 

--- a/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
@@ -3,11 +3,12 @@ from custom_components.ecoflow_cloud.devices import const, BaseDevice
 from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
 from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity
 from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
-    TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, OutWattsDcSensorEntity, InWattsSolarSensorEntity, \
-    InEnergySensorEntity, OutEnergySensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, CapacitySensorEntity, ReconnectStatusSensorEntity, QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
+    CyclesSensorEntity, \
+    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
+    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
+    InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
+    AmpSensorEntity, InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -15,9 +16,13 @@ class DeltaMini(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(client, self, "bmsMaster.f32ShowSoc", const.MAIN_BATTERY_LEVEL_F32, False)
+                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
@@ -25,7 +30,7 @@ class DeltaMini(BaseDevice):
             LevelSensorEntity(client, self, "bmsMaster.soh", const.SOH),
 
             LevelSensorEntity(client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-
+            LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
 
@@ -36,11 +41,14 @@ class DeltaMini(BaseDevice):
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
 
             InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
+            InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
+            InAmpSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
 
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
+            OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
 
             OutWattsDcSensorEntity(client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
-            OutWattsSensorEntity(client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
+            OutWattsDcSensorEntity(client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
 
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
@@ -56,12 +64,13 @@ class DeltaMini(BaseDevice):
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
 
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP, False)
-            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
 
+            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
 
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),

--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
@@ -6,12 +6,12 @@ from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatte
     MinGenStartLevelEntity, \
     MaxGenStopLevelEntity
 from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
-    TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, OutWattsDcSensorEntity, InWattsSolarSensorEntity, \
-    InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity, \
-    InEnergySensorEntity, OutEnergySensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, AmpSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
+    CyclesSensorEntity, \
+    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
+    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
+    InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
+    AmpSensorEntity, InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -19,23 +19,23 @@ class DeltaPro(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             LevelSensorEntity(client, self, "bmsMaster.f32ShowSoc", const.MAIN_BATTERY_LEVEL_F32, False)
-            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
+
             LevelSensorEntity(client, self, "bmsMaster.soh", const.SOH),
 
             LevelSensorEntity(client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
             LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
@@ -50,8 +50,8 @@ class DeltaPro(BaseDevice):
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
 
-            OutWattsSensorEntity(client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
-            OutWattsSensorEntity(client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
+            OutWattsDcSensorEntity(client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
+            OutWattsDcSensorEntity(client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
 
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
@@ -67,14 +67,15 @@ class DeltaPro(BaseDevice):
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
 
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP)
-            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
             TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
 
+            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
 
@@ -87,13 +88,13 @@ class DeltaPro(BaseDevice):
 
             # Optional Slave Batteries
             LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_N_BATTERY_LEVEL % 1, False, True)
-            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             LevelSensorEntity(client, self, "bmsSlave1.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 1, False, False)
-            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_N_DESIGN_CAPACITY % 1, False),
             CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_N_FULL_CAPACITY % 1, False),
             CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 1, False),
@@ -106,13 +107,13 @@ class DeltaPro(BaseDevice):
             WattsSensorEntity(client, self, "bmsSlave1.outputWatts", const.SLAVE_N_OUT_POWER % 1, False, True),
 
             LevelSensorEntity(client, self, "bmsSlave2.soc", const.SLAVE_N_BATTERY_LEVEL % 2, False, True)
-            .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             LevelSensorEntity(client, self, "bmsSlave2.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 2, False, False)
-            .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-            .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             CapacitySensorEntity(client, self, "bmsSlave2.designCap", const.SLAVE_N_DESIGN_CAPACITY % 2, False),
             CapacitySensorEntity(client, self, "bmsSlave2.fullCap", const.SLAVE_N_FULL_CAPACITY % 2, False),
             CapacitySensorEntity(client, self, "bmsSlave2.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 2, False),
@@ -126,8 +127,8 @@ class DeltaPro(BaseDevice):
             MilliVoltSensorEntity(client, self, "bmsSlave2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
             AmpSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
             TempSensorEntity(client, self, "bmsSlave2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
-            .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-            .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+                .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+                .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
             WattsSensorEntity(client, self, "bmsSlave2.inputWatts", const.SLAVE_N_IN_POWER % 2, False, True),
             WattsSensorEntity(client, self, "bmsSlave2.outputWatts", const.SLAVE_N_OUT_POWER % 2, False, True),
             CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_N_CYCLES % 1, False),

--- a/custom_components/ecoflow_cloud/devices/internal/river_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_max.py
@@ -2,11 +2,11 @@ from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
 from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
 from custom_components.ecoflow_cloud.number import MaxBatteryLevelEntity
-from custom_components.ecoflow_cloud.select import DictSelectEntity
+from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
     TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, InEnergySensorEntity, OutEnergySensorEntity, \
-    MilliVoltSensorEntity, InMilliVoltSensorEntity, \
+    CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
+    InAmpSensorEntity, AmpSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
     OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
 from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity, FanModeEntity
 
@@ -22,8 +22,12 @@ class RiverMax(BaseDevice):
             CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
 
+            LevelSensorEntity(client, self, "pd.soc", const.COMBINED_BATTERY_LEVEL),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
+
+            InAmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
@@ -32,8 +36,10 @@ class RiverMax(BaseDevice):
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
 
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
-
             OutWattsSensorEntity(client, self, "pd.typecWatts", const.TYPEC_OUT_POWER),
+            # disabled by default because they aren't terribly useful
+            TempSensorEntity(client, self, "pd.carTemp", const.DC_CAR_OUT_TEMP, False),
+            TempSensorEntity(client, self, "pd.typecTemp", const.USB_C_TEMP, False),
 
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
@@ -48,11 +54,15 @@ class RiverMax(BaseDevice):
             TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
 
+            AmpSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
                 .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
+
+            TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
+            TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
 
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
@@ -61,6 +71,7 @@ class RiverMax(BaseDevice):
             OutEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
             OutEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
 
+            # Optional Slave Batteries
             LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL, False, True)
                 .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
                 .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
@@ -75,11 +86,12 @@ class RiverMax(BaseDevice):
             TempSensorEntity(client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
 
-            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.BATTERY_VOLT, False)
+            AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False)
                 .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.MAX_CELL_VOLT, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
+            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
 
             CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_CYCLES, False, True),
             QuotaStatusSensorEntity(client, self)
@@ -87,8 +99,7 @@ class RiverMax(BaseDevice):
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bmsMaster.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100, None),
-            # MinBatteryLevelEntity(client, self, "bmsMaster.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30, None),
+            MaxBatteryLevelEntity(client, self, "bmsMaster.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 49, "maxChgSoc": value}}),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
@@ -103,8 +114,9 @@ class RiverMax(BaseDevice):
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
 
-            DictSelectEntity(client, self, "pd.standByMode", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 33, "standByMode": value}}),
-            DictSelectEntity(client, self, "inv.cfgStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 153, "standByMins": value}}),
+            TimeoutDictSelectEntity(client, self, "pd.standByMode", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 33, "standByMode": value}}),
+            TimeoutDictSelectEntity(client, self, "pd.carDelayOffMin", const.DC_TIMEOUT, const.DC_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"cmdSet": 32, "id": 84, "carDelayOffMin": value}}),
+            TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 153, "standByMins": value}}),
 
         ]
 

--- a/custom_components/ecoflow_cloud/devices/internal/river_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_pro.py
@@ -6,9 +6,8 @@ from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
     TempSensorEntity, \
     CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    InVoltSensorEntity, \
     InAmpSensorEntity, AmpSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, CapacitySensorEntity, ReconnectStatusSensorEntity, QuotaStatusSensorEntity
+    OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
 from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity
 
 
@@ -19,15 +18,17 @@ class RiverPro(BaseDevice):
                 .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
                 .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
                 .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
+            # Not available on River Pro units
+            # CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
 
+            LevelSensorEntity(client, self, "pd.soc", const.COMBINED_BATTERY_LEVEL),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
 
             InAmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
+            InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
@@ -46,12 +47,21 @@ class RiverPro(BaseDevice):
             OutWattsSensorEntity(client, self, "pd.usb3Watts", const.USB_3_OUT_POWER),
 
             RemainSensorEntity(client, self, "pd.remainTime", const.REMAINING_TIME),
+            CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
+
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP)
                 .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
                 .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-
             TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
+
+            AmpSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
+            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
+                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
+            MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
+
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
 
@@ -62,22 +72,13 @@ class RiverPro(BaseDevice):
             OutEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
             OutEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
 
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
-
-            CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
-
-
             # Optional Slave Batteries
             LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL, False, True)
                 .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
                 .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
                 .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_DESIGN_CAPACITY, False),
+            # Not available on River Pro units
+            # CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_DESIGN_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_FULL_CAPACITY, False),
             CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_REMAIN_CAPACITY, False),
 
@@ -85,6 +86,8 @@ class RiverPro(BaseDevice):
             TempSensorEntity(client, self, "bmsSlave1.temp", const.SLAVE_BATTERY_TEMP, False, True)
                 .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
                 .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
+            TempSensorEntity(client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
 
             AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False)
@@ -92,18 +95,12 @@ class RiverPro(BaseDevice):
                 .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
-
-
             QuotaStatusSensorEntity(client, self)
-
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bmsMaster.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 49, "maxChgSoc": value}}),
-            # MinBatteryLevelEntity(client, self, "bmsMaster.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30, None),
+            MaxBatteryLevelEntity(client, self, "bmsMaster.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 49, "maxChgSoc": value}}),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -212,7 +212,6 @@ class EnergySensorEntity(BaseSensorEntity):
 
 
 class CapacitySensorEntity(BaseSensorEntity):
-    _attr_device_class = SensorDeviceClass.CURRENT
     _attr_native_unit_of_measurement = "mAh"
     _attr_state_class = SensorStateClass.MEASUREMENT
 

--- a/docs/devices/DELTA_MAX.md
+++ b/docs/devices/DELTA_MAX.md
@@ -2,18 +2,25 @@
 
 *Sensors*
 - Main Battery Level (`bmsMaster.soc`)
+- Main Battery Level (Precise) (`bmsMaster.f32ShowSoc`)   _(disabled)_
 - Main Design Capacity (`bmsMaster.designCap`)   _(disabled)_
 - Main Full Capacity (`bmsMaster.fullCap`)   _(disabled)_
 - Main Remain Capacity (`bmsMaster.remainCap`)   _(disabled)_
+- State of Health (`bmsMaster.soh`)
 - Battery Level (`ems.lcdShowSoc`)
+- Battery Level (Precise) (`ems.f32LcdShowSoc`)   _(disabled)_
 - Total In Power (`pd.wattsInSum`)
 - Total Out Power (`pd.wattsOutSum`)
+- Main Battery Current (`bmsMaster.amp`)
 - AC In Power (`inv.inputWatts`)
 - AC Out Power (`inv.outputWatts`)
 - AC In Volts (`inv.acInVol`)
 - AC Out Volts (`inv.invOutVol`)
 - Solar In Power (`mppt.inWatts`)
+- Solar In Voltage (`mppt.inVol`)
+- Solar In Current (`mppt.inAmp`)
 - DC Out Power (`mppt.outWatts`)
+- DC Out Voltage (`mppt.outVol`)
 - Type-C (1) Out Power (`pd.typec1Watts`)
 - Type-C (2) Out Power (`pd.typec2Watts`)
 - USB (1) Out Power (`pd.usb1Watts`)
@@ -30,6 +37,39 @@
 - Battery Volts (`bmsMaster.vol`)   _(disabled)_
 - Min Cell Volts (`bmsMaster.minCellVol`)   _(disabled)_
 - Max Cell Volts (`bmsMaster.maxCellVol`)   _(disabled)_
+- Solar In Energy (`pd.chgSunPower`)
+- Battery Charge Energy from AC (`pd.chgPowerAc`)
+- Battery Charge Energy from DC (`pd.chgPowerDc`)
+- Battery Discharge Energy to AC (`pd.dsgPowerAc`)
+- Battery Discharge Energy to DC (`pd.dsgPowerDc`)
+- Slave 1 Battery Level (`bmsSlave1.soc`)   _(auto)_
+- Slave 1 Battery Level (Precise) (`bmsSlave1.f32ShowSoc`)   _(disabled)_
+- Slave 1 Design Capacity (`bmsSlave1.designCap`)   _(disabled)_
+- Slave 1 Full Capacity (`bmsSlave1.fullCap`)   _(disabled)_
+- Slave 1 Remain Capacity (`bmsSlave1.remainCap`)   _(disabled)_
+- Slave 1 State of Health (`bmsSlave1.soh`)
+- Slave 1 Battery Temperature (`bmsSlave1.temp`)   _(auto)_
+- Slave 1 In Power (`bmsSlave1.inputWatts`)   _(auto)_
+- Slave 1 Out Power (`bmsSlave1.outputWatts`)   _(auto)_
+- Slave 2 Battery Level (`bmsSlave2.soc`)   _(auto)_
+- Slave 2 Battery Level (Precise) (`bmsSlave2.f32ShowSoc`)   _(disabled)_
+- Slave 2 Design Capacity (`bmsSlave2.designCap`)   _(disabled)_
+- Slave 2 Full Capacity (`bmsSlave2.fullCap`)   _(disabled)_
+- Slave 2 Remain Capacity (`bmsSlave2.remainCap`)   _(disabled)_
+- Slave 2 State of Health (`bmsSlave2.soh`)
+- Slave 1 Battery Volts (`bmsSlave1.vol`)   _(disabled)_
+- Slave 1 Min Cell Volts (`bmsSlave1.minCellVol`)   _(disabled)_
+- Slave 1 Max Cell Volts (`bmsSlave1.maxCellVol`)   _(disabled)_
+- Slave 1 Battery Current (`bmsSlave1.amp`)   _(disabled)_
+- Slave 2 Battery Volts (`bmsSlave2.vol`)   _(disabled)_
+- Slave 2 Min Cell Volts (`bmsSlave2.minCellVol`)   _(disabled)_
+- Slave 2 Max Cell Volts (`bmsSlave2.maxCellVol`)   _(disabled)_
+- Slave 2 Battery Current (`bmsSlave2.amp`)   _(disabled)_
+- Slave 2 Battery Temperature (`bmsSlave2.temp`)   _(auto)_
+- Slave 2 In Power (`bmsSlave2.inputWatts`)   _(auto)_
+- Slave 2 Out Power (`bmsSlave2.outputWatts`)   _(auto)_
+- Slave 1 Cycles (`bmsSlave1.cycles`)   _(disabled)_
+- Slave 2 Cycles (`bmsSlave2.cycles`)   _(disabled)_
 - Status
 
 *Switches*
@@ -46,7 +86,7 @@
 - Min Discharge Level (`ems.minDsgSoc` -> `{"moduleType": 2, "operateType": "TCP", "params": {"id": 51, "minDsgSoc": "VALUE"}}` [0 - 30])
 - Generator Auto Start Level (`ems.minOpenOilEbSoc` -> `{"moduleType": 2, "operateType": "TCP", "params": {"id": 52, "openOilSoc": "VALUE"}}` [0 - 30])
 - Generator Auto Stop Level (`ems.maxCloseOilEbSoc` -> `{"moduleType": 2, "operateType": "TCP", "params": {"id": 53, "closeOilSoc": "VALUE"}}` [50 - 100])
-- AC Charging Power (`inv.cfgFastChgWatt` -> `{"moduleType": 0, "operateType": "TCP", "params": {"slowChgPower": "VALUE", "id": 69}}` [200 - 2000])
+- AC Charging Power (`inv.cfgSlowChgWatts` -> `{"moduleType": 0, "operateType": "TCP", "params": {"slowChgPower": "VALUE", "id": 69}}` [100 - 2000])
 
 *Selects*
 

--- a/docs/devices/DELTA_MINI.md
+++ b/docs/devices/DELTA_MINI.md
@@ -2,11 +2,13 @@
 
 *Sensors*
 - Main Battery Level (`bmsMaster.soc`)
+- Main Battery Level (Precise) (`bmsMaster.f32ShowSoc`)   _(disabled)_
 - Main Design Capacity (`bmsMaster.designCap`)   _(disabled)_
 - Main Full Capacity (`bmsMaster.fullCap`)   _(disabled)_
 - Main Remain Capacity (`bmsMaster.remainCap`)   _(disabled)_
 - State of Health (`bmsMaster.soh`)
 - Battery Level (`ems.lcdShowSoc`)
+- Battery Level (Precise) (`ems.f32LcdShowSoc`)   _(disabled)_
 - Total In Power (`pd.wattsInSum`)
 - Total Out Power (`pd.wattsOutSum`)
 - AC In Power (`inv.inputWatts`)
@@ -14,7 +16,10 @@
 - AC In Volts (`inv.acInVol`)
 - AC Out Volts (`inv.invOutVol`)
 - Solar In Power (`mppt.inWatts`)
+- Solar In Voltage (`mppt.inVol`)
+- Solar In Current (`mppt.inAmp`)
 - DC Out Power (`mppt.outWatts`)
+- DC Out Voltage (`mppt.outVol`)
 - DC Car Out Power (`mppt.carOutWatts`)
 - DC Anderson Out Power (`mppt.dcdc12vWatts`)
 - Type-C (1) Out Power (`pd.typec1Watts`)
@@ -27,6 +32,7 @@
 - Discharge Remaining Time (`ems.dsgRemainTime`)
 - Cycles (`bmsMaster.cycles`)
 - Battery Temperature (`bmsMaster.temp`)   _(disabled)_
+- Main Battery Current (`bmsMaster.amp`)   _(disabled)_
 - Battery Volts (`bmsMaster.vol`)   _(disabled)_
 - Solar In Energy (`pd.chgSunPower`)
 - Battery Charge Energy from AC (`pd.chgPowerAc`)

--- a/docs/devices/DELTA_PRO.md
+++ b/docs/devices/DELTA_PRO.md
@@ -11,7 +11,6 @@
 - Battery Level (Precise) (`ems.f32LcdShowSoc`)   _(disabled)_
 - Total In Power (`pd.wattsInSum`)
 - Total Out Power (`pd.wattsOutSum`)
-- Main Battery Current (`bmsMaster.amp`)
 - AC In Power (`inv.inputWatts`)
 - AC Out Power (`inv.outputWatts`)
 - AC In Volts (`inv.acInVol`)
@@ -35,6 +34,7 @@
 - Battery Temperature (`bmsMaster.temp`)
 - Min Cell Temperature (`bmsMaster.minCellTemp`)   _(disabled)_
 - Max Cell Temperature (`bmsMaster.maxCellTemp`)   _(disabled)_
+- Main Battery Current (`bmsMaster.amp`)   _(disabled)_
 - Battery Volts (`bmsMaster.vol`)   _(disabled)_
 - Min Cell Volts (`bmsMaster.minCellVol`)   _(disabled)_
 - Max Cell Volts (`bmsMaster.maxCellVol`)   _(disabled)_
@@ -84,7 +84,7 @@
 *Sliders (numbers)*
 - Max Charge Level (`ems.maxChargeSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 49, "maxChgSoc": "VALUE"}}` [50 - 100])
 - Min Discharge Level (`ems.minDsgSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 51, "minDsgSoc": "VALUE"}}` [0 - 30])
-- Backup Reserve Level (`pd.bpPowerSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"isConfig": 1, "bpPowerSoc": "VALUE", "minDsgSoc": 0, "maxChgSoc": 0, "id": 94}}` [5 - 100])
+- Backup Reserve Level (`pd.bppowerSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"isConfig": 1, "bpPowerSoc": "VALUE", "minDsgSoc": 0, "maxChgSoc": 0, "id": 94}}` [5 - 100])
 - Generator Auto Start Level (`ems.minOpenOilEbSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"openOilSoc": "VALUE", "id": 52}}` [0 - 30])
 - Generator Auto Stop Level (`ems.maxCloseOilEbSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"closeOilSoc": "VALUE", "id": 53}}` [50 - 100])
 - AC Charging Power (`inv.cfgSlowChgWatts` -> `{"moduleType": 0, "operateType": "TCP", "params": {"slowChgPower": "VALUE", "id": 69}}` [200 - 2900])

--- a/docs/devices/DELTA_Pro-Public.md
+++ b/docs/devices/DELTA_Pro-Public.md
@@ -84,7 +84,7 @@
 *Sliders (numbers)*
 - Max Charge Level (`ems.maxChargeSoc` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "id": 49, "maxChgSoc": "VALUE"}}` [50 - 100])
 - Min Discharge Level (`ems.minDsgSoc` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "id": 51, "minDsgSoc": "VALUE"}}` [0 - 30])
-- Backup Reserve Level (`pd.bpPowerSoc` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "isConfig": 1, "bpPowerSoc": "VALUE", "minDsgSoc": 0, "maxChgSoc": 0, "id": 94}}` [5 - 100])
+- Backup Reserve Level (`pd.bppowerSoc` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "isConfig": 1, "bpPowerSoc": "VALUE", "minDsgSoc": 0, "maxChgSoc": 0, "id": 94}}` [5 - 100])
 - Generator Auto Start Level (`ems.minOpenOilEbSoc` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "openOilSoc": "VALUE", "id": 52}}` [0 - 30])
 - Generator Auto Stop Level (`ems.maxCloseOilEbSoc` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "closeOilSoc": "VALUE", "id": 53}}` [50 - 100])
 - AC Charging Power (`inv.cfgSlowChgWatts` -> `{"operateType": "TCP", "params": {"cmdSet": 32, "slowChgPower": "VALUE", "id": 69}}` [200 - 2900])

--- a/docs/devices/RIVER_MAX.md
+++ b/docs/devices/RIVER_MAX.md
@@ -5,14 +5,19 @@
 - Main Design Capacity (`bmsMaster.designCap`)   _(disabled)_
 - Main Full Capacity (`bmsMaster.fullCap`)   _(disabled)_
 - Main Remain Capacity (`bmsMaster.remainCap`)   _(disabled)_
+- Battery Level (`pd.soc`)
 - Total In Power (`pd.wattsInSum`)
 - Total Out Power (`pd.wattsOutSum`)
+- Solar In Current (`inv.dcInAmp`)
+- Solar In Voltage (`inv.dcInVol`)
 - AC In Power (`inv.inputWatts`)
 - AC Out Power (`inv.outputWatts`)
 - AC In Volts (`inv.acInVol`)
 - AC Out Volts (`inv.invOutVol`)
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typecWatts`)
+- DC Temperature (`pd.carTemp`)   _(disabled)_
+- USB C Temperature (`pd.typecTemp`)   _(disabled)_
 - USB (1) Out Power (`pd.usb1Watts`)
 - USB (2) Out Power (`pd.usb2Watts`)
 - USB (3) Out Power (`pd.usb3Watts`)
@@ -21,9 +26,12 @@
 - Battery Temperature (`bmsMaster.temp`)
 - Min Cell Temperature (`bmsMaster.minCellTemp`)   _(disabled)_
 - Max Cell Temperature (`bmsMaster.maxCellTemp`)   _(disabled)_
+- Battery Current (`bmsMaster.amp`)   _(disabled)_
 - Battery Volts (`bmsMaster.vol`)   _(disabled)_
 - Min Cell Volts (`bmsMaster.minCellVol`)   _(disabled)_
 - Max Cell Volts (`bmsMaster.maxCellVol`)   _(disabled)_
+- Inverter Inside Temperature (`inv.inTemp`)
+- Inverter Outside Temperature (`inv.outTemp`)
 - Solar In Energy (`pd.chgSunPower`)
 - Battery Charge Energy from AC (`pd.chgPowerAC`)
 - Battery Charge Energy from DC (`pd.chgPowerDC`)
@@ -36,9 +44,10 @@
 - Slave Battery Temperature (`bmsSlave1.temp`)   _(auto)_
 - Slave Min Cell Temperature (`bmsSlave1.minCellTemp`)   _(disabled)_
 - Slave Max Cell Temperature (`bmsSlave1.maxCellTemp`)   _(disabled)_
-- Battery Volts (`bmsSlave1.vol`)   _(disabled)_
-- Min Cell Volts (`bmsSlave1.minCellVol`)   _(disabled)_
-- Max Cell Volts (`bmsSlave1.maxCellVol`)   _(disabled)_
+- Slave Battery Current (`bmsSlave1.amp`)   _(disabled)_
+- Slave Battery Volts (`bmsSlave1.vol`)   _(disabled)_
+- Slave Min Cell Volts (`bmsSlave1.minCellVol`)   _(disabled)_
+- Slave Max Cell Volts (`bmsSlave1.maxCellVol`)   _(disabled)_
 - Slave Cycles (`bmsSlave1.cycles`)   _(auto)_
 - Status
 
@@ -50,10 +59,11 @@
 - Auto Fan Speed (`inv.cfgFanMode` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 73, "fanMode": "VALUE"}}`)
 
 *Sliders (numbers)*
-- Max Charge Level (`bmsMaster.maxChargeSoc` -> `_ command not available _` [30 - 100])
+- Max Charge Level (`bmsMaster.maxChargeSoc` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 49, "maxChgSoc": "VALUE"}}` [30 - 100])
 
 *Selects*
-- Unit Timeout (`pd.standByMode` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 33, "standByMode": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
-- AC Timeout (`inv.cfgStandbyMin` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 153, "standByMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
+- Unit Timeout (`pd.standByMode` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 33, "standByMode": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 6 hr (360), 12 hr (720)])
+- DC (12V) Timeout (`pd.carDelayOffMin` -> `{"moduleType": 0, "operateType": "TCP", "params": {"cmdSet": 32, "id": 84, "carDelayOffMin": "VALUE"}}` [Never (0), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
+- AC Timeout (`inv.cfgStandbyMin` -> `{"moduleType": 0, "operateType": "TCP", "params": {"id": 153, "standByMins": "VALUE"}}` [Never (0), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
 

--- a/docs/devices/RIVER_PRO.md
+++ b/docs/devices/RIVER_PRO.md
@@ -5,6 +5,7 @@
 - Main Design Capacity (`bmsMaster.designCap`)   _(disabled)_
 - Main Full Capacity (`bmsMaster.fullCap`)   _(disabled)_
 - Main Remain Capacity (`bmsMaster.remainCap`)   _(disabled)_
+- Battery Level (`pd.soc`)
 - Total In Power (`pd.wattsInSum`)
 - Total Out Power (`pd.wattsOutSum`)
 - Solar In Current (`inv.dcInAmp`)
@@ -21,9 +22,14 @@
 - USB (2) Out Power (`pd.usb2Watts`)
 - USB (3) Out Power (`pd.usb3Watts`)
 - Remaining Time (`pd.remainTime`)
+- Cycles (`bmsMaster.cycles`)
 - Battery Temperature (`bmsMaster.temp`)
 - Min Cell Temperature (`bmsMaster.minCellTemp`)   _(disabled)_
 - Max Cell Temperature (`bmsMaster.maxCellTemp`)   _(disabled)_
+- Battery Current (`bmsMaster.amp`)   _(disabled)_
+- Battery Volts (`bmsMaster.vol`)   _(disabled)_
+- Min Cell Volts (`bmsMaster.minCellVol`)   _(disabled)_
+- Max Cell Volts (`bmsMaster.maxCellVol`)   _(disabled)_
 - Inverter Inside Temperature (`inv.inTemp`)
 - Inverter Outside Temperature (`inv.outTemp`)
 - Solar In Energy (`pd.chgSunPower`)
@@ -31,17 +37,14 @@
 - Battery Charge Energy from DC (`pd.chgPowerDC`)
 - Battery Discharge Energy to AC (`pd.dsgPowerAC`)
 - Battery Discharge Energy to DC (`pd.dsgPowerDC`)
-- Battery Current (`bmsMaster.amp`)   _(disabled)_
-- Battery Volts (`bmsMaster.vol`)   _(disabled)_
-- Min Cell Volts (`bmsMaster.minCellVol`)   _(disabled)_
-- Max Cell Volts (`bmsMaster.maxCellVol`)   _(disabled)_
-- Cycles (`bmsMaster.cycles`)
 - Slave Battery Level (`bmsSlave1.soc`)   _(auto)_
 - Slave Design Capacity (`bmsSlave1.designCap`)   _(disabled)_
 - Slave Full Capacity (`bmsSlave1.fullCap`)   _(disabled)_
 - Slave Remain Capacity (`bmsSlave1.remainCap`)   _(disabled)_
 - Slave Cycles (`bmsSlave1.cycles`)   _(auto)_
 - Slave Battery Temperature (`bmsSlave1.temp`)   _(auto)_
+- Slave Min Cell Temperature (`bmsSlave1.minCellTemp`)   _(disabled)_
+- Slave Max Cell Temperature (`bmsSlave1.maxCellTemp`)   _(disabled)_
 - Slave Battery Current (`bmsSlave1.amp`)   _(disabled)_
 - Slave Battery Volts (`bmsSlave1.vol`)   _(disabled)_
 - Slave Min Cell Volts (`bmsSlave1.minCellVol`)   _(disabled)_


### PR DESCRIPTION
- Re-ran documentation builder
- Changed capacity sensors to not be tagged as a measure of CURRENT. Capacity (mAh) is not current (mA). This removes some log warnings.
- Delta Max: Added solar voltage/current, DC out voltage, slave 2 battery support, energy sensors
- Delta Mini: Added solar voltage/current, DC out voltage, battery current
- Delta Mini: Changed DC anderson out to OutWattsDcSensorEntity so the value is scaled properly.
- Delta Pro: Reordered code to be consistent with Delta Max/Mini.
- Delta Pro: Fixed DC output watts to use correct sensor type so value is correctly scaled
- Delta Pro: Added battery current sensor
- River Max: Added missing sensors for solar, temp, and battery amps
- River Max: Added DC timeout and updated timeouts to use TimeoutDictSelectEntity
- River Max: Fixed max charge level, which was missing lambda. Assumed 49, like River Pro
- River Max: Fixed incorrect slave battery attributes
- River Pro: Added sensors for battery cycles, battery voltage, combined SOC, and slave battery temp.