### PR TITLE
[Fix for issue #396] Ignoring devices from device list response with missing keys

### DIFF
--- a/custom_components/ecoflow_cloud/api/public_api.py
+++ b/custom_components/ecoflow_cloud/api/public_api.py
@@ -40,10 +40,14 @@ class EcoflowPublicApiClient(EcoflowApiClient):
         self.mqtt_info.client_id = f"Hassio-{self.mqtt_info.username}-{self.group.replace(' ', '-')}"
 
     async def fetch_all_available_devices(self) -> list[EcoflowDeviceInfo]:
-        _LOGGER.info(f"Requesting all devices")
+        _LOGGER.info("Requesting all devices")
         response = await self.call_api("/device/list")
         result = list()
+        required_keys = {"sn", "productName", "online"}
         for device in response["data"]:
+            if not all(key in device for key in required_keys):
+                _LOGGER.warning(f"Skipping device due to missing keys: {device}")
+                continue
             sn = device["sn"]
             product_name = device["productName"]
             device_name = device.get("deviceName", f"{product_name}-{sn}")


### PR DESCRIPTION
The /device/list endpoint did return my Delta 3 Plus with a missing puductName field. 
This change ignores all devices that don't include a "sn", "online"-status and a "productName".

`{
	'code': '0',
	'message': 'Success',
	'data': [{
		'sn': 'XXXXXXXX,
		'online': 0,
		'productName': 'PowerStream'
	}, {
		'sn': 'XXXXXXXX',
		'deviceName': 'PowerStream Delta Pro 3',
		'online': 0,
		'productName': 'PowerStream'
	}, {
		'sn': 'XXXXXXXX',
		'deviceName': 'WAVE 2',
		'online': 0,
		'productName': 'WAVE 2'
	}, {
		'sn': 'XXXXXXXX',
		'deviceName': 'DELTA Pro 3',
		'online': 1,
		'productName': 'DELTA Pro 3'
	}, {
		'sn': 'XXXXXXXX',
		'deviceName': 'Delta 3 Plus',
		'online': 1
	}],
	'eagleEyeTraceId': 'ea1a2a582917358540634803952d0007',
	'tid': ''
}`