### PR TITLE
Fix powerkit integration to create entries again

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -177,7 +177,8 @@ def extract_devices(entry: ConfigEntry) -> dict[str, DeviceData]:
     for sn, data in entry.data[CONF_DEVICE_LIST].items():
         if CONF_PARENT_SN in data:
             result[sn.split(".")[-1]].parent = parent
-
+    if not result:
+        result[parent.sn] = parent
     return result
 
 

--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -152,9 +152,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 def extract_devices(entry: ConfigEntry) -> dict[str, DeviceData]:
     result = dict[str, DeviceData]()
+    parent = None
     for sn, data in entry.data[CONF_DEVICE_LIST].items():
-        result[sn] = DeviceData(
-            sn,
+        realsn = sn
+        if CONF_PARENT_SN in data:
+            realsn = sn.split(".")[-1]
+        devicedata = DeviceData(
+            realsn,
             data[CONF_DEVICE_NAME],
             data[CONF_DEVICE_TYPE],
             DeviceOptions(
@@ -165,10 +169,14 @@ def extract_devices(entry: ConfigEntry) -> dict[str, DeviceData]:
             None,
             None,
         )
+        if CONF_PARENT_SN in data:
+            result[realsn] = devicedata
+        else:
+            parent = devicedata
 
     for sn, data in entry.data[CONF_DEVICE_LIST].items():
         if CONF_PARENT_SN in data:
-            result[sn].parent = result[data[CONF_PARENT_SN]]
+            result[sn.split(".")[-1]].parent = parent
 
     return result
 

--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -101,7 +101,8 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
 
             from .devices.registry import device_support_sub_devices
 
-            for sn, device_data in self.new_data[CONF_DEVICE_LIST].items():
+            data = self.new_data[CONF_DEVICE_LIST]
+            for sn, device_data in data.copy().items():
                 if device_data[CONF_DEVICE_TYPE] not in device_support_sub_devices:
                     # skip here all devices that do not support sub devices
                     continue
@@ -114,7 +115,11 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
                 all_device_info = await self.auth.call_api(
                     "/device/quota/all", {"sn": sn}
                 )
-                for sub_device_type, sub_devices in all_device_info["data"].items():
+                potentialSubdevices = self.transform_potential_subdevices(
+                    all_device_info["data"]
+                )
+
+                for sub_device_type, sub_devices in potentialSubdevices.items():
                     if not isinstance(sub_devices, dict):
                         continue
                     for sub_device_sn, item in sub_devices.items():
@@ -135,6 +140,36 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
                 data=self.new_data,
                 options=self.new_options,
             )
+
+    def transform_potential_subdevices(
+        self,
+        potential_subdevices: dict[str, Any],
+    ) -> dict[str, dict[str, dict[str, Any]]]:
+        """
+        Transform the potential subdevices dictionary into a nested dictionary format.
+
+        Args:
+            potential_subdevices (dict[str, Any]): The potential subdevices dictionary.
+
+        Returns:
+            dict[str, dict[str, dict[str, Any]]]: The transformed nested dictionary.
+        """
+        transformed = {}
+        for key, value in potential_subdevices.items():
+            parts = key.split(".")
+            if len(parts) != 3:
+                # we expect here that the dict is already in the transformed format
+                continue
+            main_key, sub_key, final_key = parts
+            if main_key not in transformed:
+                transformed[main_key] = {}
+            if sub_key not in transformed[main_key]:
+                transformed[main_key][sub_key] = {}
+            transformed[main_key][sub_key][final_key] = value
+        if not transformed:
+            # we expect here that the input dictionary was already in the correct format
+            return potential_subdevices
+        return transformed
 
     def remove_device(self, sn: str):
         # Get the device registry

--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -126,14 +126,17 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
                         if not isinstance(item, (dict, list)):
                             # skip all element that are simple
                             continue
-                        self.new_data[CONF_DEVICE_LIST][sub_device_sn] = {
+                        self.new_data[CONF_DEVICE_LIST][
+                            f"{device_data[CONF_DEVICE_NAME]}.{sub_device_type}.{sub_device_sn}"
+                        ] = {
                             CONF_DEVICE_NAME: f"{device_data[CONF_DEVICE_NAME]}.{sub_device_type}.{sub_device_sn}",
                             CONF_DEVICE_TYPE: sub_device_type,
                             CONF_PARENT_SN: sn,
                         }
-                        self.new_options[CONF_DEVICE_LIST][sub_device_sn] = (
-                            self.new_options[CONF_DEVICE_LIST][sn]
-                        )
+                        # use here the parents device options
+                        self.new_options[CONF_DEVICE_LIST][
+                            f"{device_data[CONF_DEVICE_NAME]}.{sub_device_type}.{sub_device_sn}"
+                        ] = self.new_options[CONF_DEVICE_LIST][sn]
 
             return self.async_create_entry(
                 title=self.new_data[CONF_GROUP],


### PR DESCRIPTION
This is a very complicated version of supporting subdevices. I would prefer the use of concret types that have a proper subdevices implementation. This implementation is very flacky because it reliese on dictionary keys and if anything unexpected happend in the code paths that are changed the possibility of an override in that dictionary is very likely.

fixes #431 

I would prefer to rollback the changes of https://github.com/tolwi/hassio-ecoflow-cloud/commit/5d7732c1488c401b73567c2a313d1bf4fcfa7889#diff-146034f7ca927c81a86406814cdde349b55138044f4620ed707e946f8b3b9ac6

But the decision is up to you @tolwi 