### PR TITLE
Renames the Amp sensors to reflect their unit

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta2_max.py
@@ -7,7 +7,7 @@ from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MinBatte
 from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
     CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, InAmpSensorEntity, \
+    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, InMilliampSensorEntity, \
     InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
@@ -41,8 +41,8 @@ class Delta2Max(BaseDevice):
 
             InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_1_IN_VOLTS), 
             InMilliVoltSensorEntity(client, self, "mppt.pv2InVol", const.SOLAR_2_IN_VOLTS), 
-            InAmpSensorEntity(client, self, "mppt.inAmp", const.SOLAR_1_IN_AMPS),        
-            InAmpSensorEntity(client, self, "mppt.pv2InAmp", const.SOLAR_2_IN_AMPS),     
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_1_IN_AMPS),
+            InMilliampSensorEntity(client, self, "mppt.pv2InAmp", const.SOLAR_2_IN_AMPS),
 
             # OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             # the same value as pd.carWatts

--- a/custom_components/ecoflow_cloud/devices/internal/delta_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_max.py
@@ -8,7 +8,7 @@ from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSenso
     InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
     InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
     InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
-    AmpSensorEntity, InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity
+    MilliampSensorEntity, InVoltSolarSensorEntity, InMilliampSolarSensorEntity, OutVoltDcSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -33,7 +33,7 @@ class DeltaMax(BaseDevice):
             LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
+            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
@@ -43,7 +43,7 @@ class DeltaMax(BaseDevice):
 
             InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InAmpSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
 
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
@@ -117,11 +117,11 @@ class DeltaMax(BaseDevice):
             MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 1, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 1, False),
-            AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
+            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
             MilliVoltSensorEntity(client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False),
             MilliVoltSensorEntity(client, self, "bmsSlave2.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 2, False),
             MilliVoltSensorEntity(client, self, "bmsSlave2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
-            AmpSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
+            MilliampSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
             TempSensorEntity(client, self, "bmsSlave2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
                 .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
                 .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),

--- a/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
@@ -8,7 +8,7 @@ from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSenso
     InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
     InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
     InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
-    AmpSensorEntity, InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity
+    MilliampSensorEntity, InVoltSolarSensorEntity, InMilliampSolarSensorEntity, OutVoltDcSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -42,7 +42,7 @@ class DeltaMini(BaseDevice):
 
             InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InAmpSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
 
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
@@ -67,7 +67,7 @@ class DeltaMini(BaseDevice):
                 .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
                 .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
 
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
+            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
                 .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),

--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
@@ -11,7 +11,7 @@ from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSenso
     InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
     InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
     InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
-    AmpSensorEntity, InVoltSolarSensorEntity, InAmpSolarSensorEntity, OutVoltDcSensorEntity
+    MilliampSensorEntity, InVoltSolarSensorEntity, InMilliampSolarSensorEntity, OutVoltDcSensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -45,7 +45,7 @@ class DeltaPro(BaseDevice):
 
             InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InAmpSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
 
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
@@ -72,7 +72,7 @@ class DeltaPro(BaseDevice):
             TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
 
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
+            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
                 .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
@@ -121,11 +121,11 @@ class DeltaPro(BaseDevice):
             MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 1, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 1, False),
-            AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
+            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
             MilliVoltSensorEntity(client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False),
             MilliVoltSensorEntity(client, self, "bmsSlave2.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 2, False),
             MilliVoltSensorEntity(client, self, "bmsSlave2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
-            AmpSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
+            MilliampSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
             TempSensorEntity(client, self, "bmsSlave2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
                 .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
                 .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),

--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -7,7 +7,7 @@ from custom_components.ecoflow_cloud.entities import (
     BaseSensorEntity, BaseNumberEntity, BaseSelectEntity, BaseSwitchEntity
 )
 from custom_components.ecoflow_cloud.sensor import (
-    AmpSensorEntity, CentivoltSensorEntity, DeciampSensorEntity,
+    MilliampSensorEntity, CentivoltSensorEntity, DeciampSensorEntity,
     DecicelsiusSensorEntity, DecihertzSensorEntity, DeciwattsSensorEntity,
     DecivoltSensorEntity, InWattsSolarSensorEntity, LevelSensorEntity,
     MiscSensorEntity, RemainSensorEntity, StatusSensorEntity, ReconnectStatusSensorEntity,
@@ -46,7 +46,7 @@ class PowerStream(BaseDevice):
             DeciwattsSensorEntity(client, self,  "bat_input_watts", "Battery Input Watts"),
             DecivoltSensorEntity(client, self,  "bat_input_volt", "Battery Input Potential"),
             DecivoltSensorEntity(client, self,  "bat_op_volt", "Battery Op Potential"),
-            AmpSensorEntity(client, self,  "bat_input_cur", "Battery Input Current"),
+            MilliampSensorEntity(client, self,  "bat_input_cur", "Battery Input Current"),
             DecicelsiusSensorEntity(client, self,  "bat_temp", "Battery Temperature"),
             RemainSensorEntity(client, self,  "battery_charge_remain", "Charge Time"),
             RemainSensorEntity(client, self,  "battery_discharge_remain", "Discharge Time"),
@@ -64,8 +64,8 @@ class PowerStream(BaseDevice):
             DeciwattsSensorEntity(client, self,  "inv_output_watts", "Inverter Output Watts"),
             DecivoltSensorEntity(client, self,  "inv_input_volt", "Inverter Output Potential", False),
             DecivoltSensorEntity(client, self,  "inv_op_volt", "Inverter Op Potential"),
-            AmpSensorEntity(client, self,  "inv_output_cur", "Inverter Output Current"),
-            AmpSensorEntity(client, self,  "inv_dc_cur", "Inverter DC Current"),
+            MilliampSensorEntity(client, self,  "inv_output_cur", "Inverter Output Current"),
+            MilliampSensorEntity(client, self,  "inv_dc_cur", "Inverter DC Current"),
             DecihertzSensorEntity(client, self,  "inv_freq", "Inverter Frequency"),
             DecicelsiusSensorEntity(client, self,  "inv_temp", "Inverter Temperature"),
             MiscSensorEntity(client, self,  "inv_relay_status", "Inverter Relay Status"),

--- a/custom_components/ecoflow_cloud/devices/internal/river2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2.py
@@ -6,7 +6,7 @@ from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumbe
 from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity, BatteryBackupLevel
 from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InAmpSensorEntity, \
+    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InMilliampSensorEntity, \
     InVoltSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
     OutMilliVoltSensorEntity, ChargingStateSensorEntity, CapacitySensorEntity, StatusSensorEntity, \
     QuotaStatusSensorEntity
@@ -38,7 +38,7 @@ class River2(BaseDevice):
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
 
-            InAmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),

--- a/custom_components/ecoflow_cloud/devices/internal/river2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_max.py
@@ -6,7 +6,7 @@ from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumbe
 from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity, BatteryBackupLevel
 from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InAmpSensorEntity, \
+    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InMilliampSensorEntity, \
     InVoltSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
     OutMilliVoltSensorEntity, ChargingStateSensorEntity, CapacitySensorEntity, StatusSensorEntity, \
     QuotaStatusSensorEntity
@@ -38,7 +38,7 @@ class River2Max(BaseDevice):
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
 
-            InAmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),

--- a/custom_components/ecoflow_cloud/devices/internal/river_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_max.py
@@ -6,7 +6,7 @@ from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
     TempSensorEntity, \
     CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    InAmpSensorEntity, AmpSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
+    InMilliampSensorEntity, MilliampSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
     OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
 from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity, FanModeEntity
 
@@ -26,7 +26,7 @@ class RiverMax(BaseDevice):
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
 
-            InAmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
@@ -54,7 +54,7 @@ class RiverMax(BaseDevice):
             TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
 
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
+            MilliampSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
                 .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
@@ -86,7 +86,7 @@ class RiverMax(BaseDevice):
             TempSensorEntity(client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
 
-            AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
+            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False)
                 .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),

--- a/custom_components/ecoflow_cloud/devices/internal/river_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_mini.py
@@ -4,7 +4,7 @@ from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumbe
 from custom_components.ecoflow_cloud.number import MaxBatteryLevelEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, TempSensorEntity, \
     CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    AmpSensorEntity, InMilliVoltSensorEntity, \
+    MilliampSensorEntity, InMilliVoltSensorEntity, \
     BeMilliVoltSensorEntity
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 
@@ -22,7 +22,7 @@ class RiverMini(BaseDevice):
             BeMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
 
             InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
-            AmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            MilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
 
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),

--- a/custom_components/ecoflow_cloud/devices/internal/river_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_pro.py
@@ -6,7 +6,7 @@ from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
     TempSensorEntity, \
     CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    InAmpSensorEntity, AmpSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
+    InMilliampSensorEntity, MilliampSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
     OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
 from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity
 
@@ -27,7 +27,7 @@ class RiverPro(BaseDevice):
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
 
-            InAmpSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
 
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
@@ -55,7 +55,7 @@ class RiverPro(BaseDevice):
             TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
 
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
+            MilliampSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
             MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
                 .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
@@ -89,7 +89,7 @@ class RiverPro(BaseDevice):
             TempSensorEntity(client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
             TempSensorEntity(client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
 
-            AmpSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
+            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
             MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False)
                 .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
                 .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),

--- a/custom_components/ecoflow_cloud/devices/public/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro.py
@@ -14,10 +14,10 @@ from ...number import (
 )
 from ...select import DictSelectEntity, TimeoutDictSelectEntity
 from ...sensor import (
-    AmpSensorEntity,
+    MilliampSensorEntity,
     CapacitySensorEntity,
     CyclesSensorEntity,
-    InAmpSolarSensorEntity,
+    InMilliampSolarSensorEntity,
     InEnergySensorEntity,
     InMilliVoltSensorEntity,
     InVoltSolarSensorEntity,
@@ -78,7 +78,7 @@ class DeltaPro(BaseDevice):
             ),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-            AmpSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
+            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
@@ -87,7 +87,7 @@ class DeltaPro(BaseDevice):
                 client, self, "mppt.inWatts", const.SOLAR_IN_POWER
             ),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InAmpSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
             OutWattsSensorEntity(
@@ -279,7 +279,7 @@ class DeltaPro(BaseDevice):
                 const.SLAVE_N_MAX_CELL_VOLT % 1,
                 False,
             ),
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False
             ),
             MilliVoltSensorEntity(
@@ -299,7 +299,7 @@ class DeltaPro(BaseDevice):
                 const.SLAVE_N_MAX_CELL_VOLT % 2,
                 False,
             ),
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False
             ),
             TempSensorEntity(

--- a/custom_components/ecoflow_cloud/devices/public/powerkit.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerkit.py
@@ -10,7 +10,7 @@ from ...entities import (
 )
 from ...number import AcChargingPowerInAmpereEntity
 from ...sensor import (
-    AmpSensorEntity,
+    MilliampSensorEntity,
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
@@ -23,7 +23,7 @@ from ...sensor import (
     LevelSensorEntity,
     MilliVoltSensorEntity,
     MiscSensorEntity,
-    OutAmpSensorEntity,
+    OutMilliampSensorEntity,
     OutMilliVoltSensorEntity,
     OutWattsSensorEntity,
     RemainSensorEntity,
@@ -112,7 +112,7 @@ class PowerKit(BaseDevice):
     ) -> list[BaseSensorEntity]:
         entityKey = mainKey + "."
         return [
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client,
                 self,
                 "amp",
@@ -202,7 +202,7 @@ class PowerKit(BaseDevice):
                 client, self, "chgInType", "BMS Charge In Type", False
             ),  # 1
             MiscSensorEntity(client, self, "chrgFlag", "BMS Charge Flag", False),  # 1
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client,
                 self,
                 "maxChgCurr",
@@ -216,13 +216,13 @@ class PowerKit(BaseDevice):
                 "BMS External Kit Type",
                 False,
             ),  # 0
-            AmpSensorEntity(client, self, "bmsChgCurr", "BMS Bus Current", False),
+            MilliampSensorEntity(client, self, "bmsChgCurr", "BMS Bus Current", False),
             DeciMilliVoltSensorEntity(
                 client, self, "busVol", "BMS Bus Voltage", True
             ),  # 454198
             MiscSensorEntity(client, self, "lsplFlag", "BMS LSPL Flag", False),  # 0
             MiscSensorEntity(client, self, "protectState", "BMS Protect State"),  # 0
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "batCurr", "BMS Battery Current", False
             ),  # 386
             FanSensorEntity(client, self, "fanLevel", "Fan Level", False),  # 2
@@ -241,7 +241,7 @@ class PowerKit(BaseDevice):
                 const.SOLAR_AND_ALT_IN_POWER,
                 True,
             ),
-            AmpSensorEntity(client, self, "batCurr", "Solar Battery Current", True),
+            MilliampSensorEntity(client, self, "batCurr", "Solar Battery Current", True),
             MilliVoltSensorEntity(
                 client, self, "batVol", "Solar Battery Voltage", True
             ),
@@ -251,7 +251,7 @@ class PowerKit(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "pv1InVol", "Solar (2) In Voltage", True
             ),
-            AmpSensorEntity(client, self, "pv1InCurr", "Solar (2) In Current", True),
+            MilliampSensorEntity(client, self, "pv1InCurr", "Solar (2) In Current", True),
             MiscSensorEntity(client, self, "pv1ErrCode", "Solar (2) Error Code", True),
             MiscSensorEntity(client, self, "pv1_hot_out", "Solar (2) Hot Out", False),
             MiscSensorEntity(
@@ -284,7 +284,7 @@ class PowerKit(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "pv2InVol", "Solar (3) In Voltage", True
             ),
-            AmpSensorEntity(client, self, "pv2InCurr", "Solar (3) In Current", True),
+            MilliampSensorEntity(client, self, "pv2InCurr", "Solar (3) In Current", True),
             MiscSensorEntity(client, self, "pv2ErrCode", "Solar (3) Error Code", True),
             MiscSensorEntity(client, self, "pv2_hot_out", "Solar (3) Hot Out", False),
             MiscSensorEntity(
@@ -311,14 +311,14 @@ class PowerKit(BaseDevice):
             ),
             MiscSensorEntity(client, self, "warnCode2", "Solar (3) Warn Code", True),
             TempSensorEntity(client, self, "hs2Temp", "Solar (3) Temperature", True),
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client,
                 self,
                 "chgEnergy",
                 "Solar Total Charge Current",
                 False,
             ),  # Not in use
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "dayEnergy", "Solar Energy for Day", False
             ),  # Not in use
         ]
@@ -329,7 +329,7 @@ class PowerKit(BaseDevice):
         entityKey = mainKey + "."
         return [
             # Power Hub DC Out
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "ldOutCurr", "DC Out Current", True
             ),  # 14999 DC output to distributer
             OutWattsSensorEntity(
@@ -338,14 +338,14 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "batWatts", "DC Out Battery Power", True
             ),  # 425 DC output from battery including BMS and Distributer power
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client,
                 self,
                 "l1Curr",
                 "DC 1 Out Battery Current",
                 False,
             ),  # 6990 DC output from battery including BMS and Distributer power
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client,
                 self,
                 "l2Curr",
@@ -400,7 +400,7 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "batWatts", "DC In Battery Power", True
             ),  # 4 DC input
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "batCurr", "DC In Battery Current", True
             ),  # 78 DC input
             MilliVoltSensorEntity(
@@ -409,7 +409,7 @@ class PowerKit(BaseDevice):
             MiscSensorEntity(
                 client, self, "allowDsgOn", "DC Allow Discharge", True
             ),  # 1 DC input
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "dsgEnergy", "DC Discharge Energy", False
             ),  # 789 Unsure what this one is. Could be some kind of total
             MiscSensorEntity(
@@ -418,7 +418,7 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "dcInWatts", "DC In Power", True
             ),  # 0 DC input
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "dcInCurr", "DC In Current", True
             ),  # 0 DC input
             MilliVoltSensorEntity(
@@ -430,7 +430,7 @@ class PowerKit(BaseDevice):
             MiscSensorEntity(
                 client, self, "chgType", "DC Charge Type", True
             ),  # 0 DC input
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client,
                 self,
                 "chgMaxCurr",
@@ -440,10 +440,10 @@ class PowerKit(BaseDevice):
             MiscSensorEntity(
                 client, self, "chargeMode", "DC Charge Mode", True
             ),  # 0 DC input
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "l1Curr", "DC In L1 Current", False
             ),  # -5 DC input
-            AmpSensorEntity(
+            MilliampSensorEntity(
                 client, self, "l2Curr", "DC In L2 Current", False
             ),  # -45 DC input
             TempSensorEntity(
@@ -487,11 +487,11 @@ class PowerKit(BaseDevice):
                 client, self, "outVol", "AC Out Voltage", True
             ),  # 240070
             # MiscSensorEntity(client, "outVa", 'AC Out VA', True), # 361
-            AmpSensorEntity(client, self, "outCurr", "AC Out Current", True),  # 2432
+            MilliampSensorEntity(client, self, "outCurr", "AC Out Current", True),  # 2432
             MiscSensorEntity(client, self, "invType", "AC Inverter Type", False),  # 0
             FrequencySensorEntity(client, self, "inFreq", "AC In Frequency", True),  # 0
             OutWattsSensorEntity(client, self, "inWatts", "AC In Power", True),  # 0
-            AmpSensorEntity(client, self, "inCurr", "AC In Current", True),  # 0
+            MilliampSensorEntity(client, self, "inCurr", "AC In Current", True),  # 0
             OutMilliVoltSensorEntity(client, self, "inVol", "AC In Voltage", True),  # 0
             MiscSensorEntity(client, self, "invSwSta", "AC Out Enabled", True),  # 1
             TempSensorEntity(
@@ -501,7 +501,7 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "ch2Watt", "AC Outlet Power", True
             ),  # 165
-            AmpSensorEntity(client, self, "outAmp2", "AC Outlet Current", True),  # 0
+            MilliampSensorEntity(client, self, "outAmp2", "AC Outlet Current", True),  # 0
             FrequencySensorEntity(
                 client,
                 self,
@@ -580,40 +580,40 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "dcChWatt[11]", "DC Out 12", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[0]", "DC Ampere Out 1", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[1]", "DC Ampere Out 2", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[2]", "DC Ampere Out 3", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[3]", "DC Ampere Out 4", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[4]", "DC Ampere Out 5", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[5]", "DC Ampere Out 6", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[6]", "DC Ampere Out 7", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[7]", "DC Ampere Out 8", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[8]", "DC Ampere Out 9", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[9]", "DC Ampere Out 10", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[10]", "DC Ampere Out 11", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "dcChCur[11]", "DC Ampere Out 12", True
             ),  # [140, 0, 0, 0, 0, 25]
             TempSensorEntity(
@@ -672,22 +672,22 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "acChWatt[5]", "AC Out 6", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "acChCur[0]", "AC Ampere Out 1", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "acChCur[1]", "AC Ampere Out 2", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "acChCur[2]", "AC Ampere Out 3", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "acChCur[3]", "AC Ampere Out 4", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "acChCur[4]", "AC Ampere Out 5", True
             ),  # [140, 0, 0, 0, 0, 25]
-            OutAmpSensorEntity(
+            OutMilliampSensorEntity(
                 client, self, "acChCur[5]", "AC Ampere Out 6", True
             ),  # [140, 0, 0, 0, 0, 25]
             OutWattsSensorEntity(

--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -13,7 +13,7 @@ from ...number import (
 )
 from ...select import PowerDictSelectEntity
 from ...sensor import (
-    AmpSensorEntity,
+    MilliampSensorEntity,
     CelsiusSensorEntity,
     CentivoltSensorEntity,
     DeciampSensorEntity,
@@ -62,7 +62,7 @@ class PowerStream(BaseDevice):
             DeciwattsSensorEntity(client, self, "20_1.batInputWatts", "Battery Input Watts"),
             DecivoltSensorEntity(client, self, "20_1.batInputVolt", "Battery Input Potential"),
             DecivoltSensorEntity(client, self, "20_1.batOpVolt", "Battery Op Potential"),
-            AmpSensorEntity(client, self, "20_1.batInputCur", "Battery Input Current"),
+            MilliampSensorEntity(client, self, "20_1.batInputCur", "Battery Input Current"),
             DecicelsiusSensorEntity(client, self, "20_1.batTemp", "Battery Temperature"),
             RemainSensorEntity(client, self, "20_1.chgRemainTime", "Charge Time"),
             RemainSensorEntity(client, self, "20_1.dsgRemainTime", "Discharge Time"),
@@ -81,8 +81,8 @@ class PowerStream(BaseDevice):
             DeciwattsSensorEntity(client, self, "20_1.invOutputWatts", "Inverter Output Watts"),
             DecivoltSensorEntity(client, self, "20_1.invInputVolt", "Inverter Output Potential", False),
             DecivoltSensorEntity(client, self, "20_1.invOpVolt", "Inverter Op Potential"),
-            AmpSensorEntity(client, self, "20_1.invOutputCur", "Inverter Output Current"),
-            #  AmpSensorEntity(client, self, "inv_dc_cur", "Inverter DC Current"),
+            MilliampSensorEntity(client, self, "20_1.invOutputCur", "Inverter Output Current"),
+            #  MilliampSensorEntity(client, self, "inv_dc_cur", "Inverter DC Current"),
             DecihertzSensorEntity(client, self, "20_1.invFreq", "Inverter Frequency"),
             DecicelsiusSensorEntity(client, self, "20_1.invTemp", "Inverter Temperature"),
             MiscSensorEntity(client, self, "20_1.invRelayStatus", "Inverter Relay Status"),

--- a/custom_components/ecoflow_cloud/devices/public/smart_plug.py
+++ b/custom_components/ecoflow_cloud/devices/public/smart_plug.py
@@ -6,7 +6,7 @@ from homeassistant.components.switch import SwitchEntity
 from ...api import EcoflowApiClient
 from ...number import BrightnessLevelEntity
 from ...sensor import (
-    AmpSensorEntity,
+    MilliampSensorEntity,
     DeciwattsSensorEntity,
     TempSensorEntity,
     VoltSensorEntity,
@@ -21,7 +21,7 @@ class SmartPlug(BaseDevice):
         return [
             TempSensorEntity(client, self, "2_1.temp", const.TEMPERATURE),
             VoltSensorEntity(client, self, "2_1.volt", const.VOLT),
-            AmpSensorEntity(client, self, "2_1.current", const.CURRENT).attr(
+            MilliampSensorEntity(client, self, "2_1.current", const.CURRENT).attr(
                 "2_1.maxCur", const.MAX_CURRENT, 0
             ),
             DeciwattsSensorEntity(client, self, "2_1.watts", const.POWER),

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -215,6 +215,14 @@ class CentivoltSensorEntity(DecivoltSensorEntity):
 class AmpSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.CURRENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_value = 0
+
+
+class MilliampSensorEntity(BaseSensorEntity):
+    _attr_device_class = SensorDeviceClass.CURRENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfElectricCurrent.MILLIAMPERE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_value = 0
@@ -323,7 +331,15 @@ class InAmpSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:transmission-tower-import"
 
 
-class InAmpSolarSensorEntity(AmpSensorEntity):
+class OutMilliampSensorEntity(MilliampSensorEntity):
+    _attr_icon = "mdi:transmission-tower-export"
+
+
+class InMilliampSensorEntity(MilliampSensorEntity):
+    _attr_icon = "mdi:transmission-tower-import"
+
+
+class InMilliampSolarSensorEntity(MilliampSensorEntity):
     _attr_icon = "mdi:solar-power"
 
     def _update_value(self, val: Any) -> bool:


### PR DESCRIPTION
- (In|Out)AmpSensorEntity -> (In|Out)MilliampSensorEntity
- AmpSolarSensorEntity -> MilliampSolarSensorEntity
- Redefines AmpSensorEntity (and the In/Out equivalents) to use Amps

This clarification is needed because Smart Home Panel 2 support is being added and it reports current as Amps, not Milliamps. There are also already Deciamp* sensors as precident.

So the integration will have:
- AmpSensorEntity (A)
- MilliampSensorEntity (mA)
- DeciampSensorEntity (A) <-- Technically reports as A after converting the deciAmp value to Amps by dividing by 10.