### PR TITLE
Add cumulative charge/discharge for Stream (AC/Ultra) and Delta 2 Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,10 +998,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> STREAM_AC <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> STREAM_AC <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles
@@ -1046,10 +1050,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> STREAM_ULTRA <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> STREAM_ULTRA <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles
@@ -1944,10 +1952,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> Stream AC (API) <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> Stream AC (API) <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles
@@ -1992,10 +2004,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> Stream Ultra (API) <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> Stream Ultra (API) <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles

--- a/README.md
+++ b/README.md
@@ -702,10 +702,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> DELTA_2_MAX <i>(sensors: 67, switches: 7, sliders: 6, selects: 3)</i> </summary>
+<details><summary> DELTA_2_MAX <i>(sensors: 71, switches: 7, sliders: 6, selects: 3)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Main Battery Level
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_
@@ -1279,10 +1283,14 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> DELTA 2 Max (API) <i>(sensors: 67, switches: 7, sliders: 6, selects: 3)</i> </summary>
+<details><summary> DELTA 2 Max (API) <i>(sensors: 71, switches: 7, sliders: 6, selects: 3)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Main Battery Level
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -330,8 +330,8 @@ STREAM_STR_IN_POWER = "In Power %s"
 STREAM_OUT_POWER = "Out Power"
 STREAM_STR_OUT_POWER = "Out Power %s"
 
-STREAM_ACCU_CHARGE_CAP = "Cumulative Capacity Charge (mAh)"
-STREAM_ACCU_CHARGE_ENERGY = "Cumulative Energy Charge (Wh)"
-STREAM_ACCU_DISCHARGE_CAP = "Cumulative Capacity Discharge (mAh)"
-STREAM_ACCU_DISCHARGE_ENERGY = "Cumulative Energy Discharge (Wh)"
+ACCU_CHARGE_CAP = "Cumulative Capacity Charge (mAh)"
+ACCU_CHARGE_ENERGY = "Cumulative Energy Charge (Wh)"
+ACCU_DISCHARGE_CAP = "Cumulative Capacity Discharge (mAh)"
+ACCU_DISCHARGE_ENERGY = "Cumulative Energy Discharge (Wh)"
 

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -329,3 +329,9 @@ STREAM_IN_POWER = "In Power"
 STREAM_STR_IN_POWER = "In Power %s"
 STREAM_OUT_POWER = "Out Power"
 STREAM_STR_OUT_POWER = "Out Power %s"
+
+STREAM_ACCU_CHARGE_CAP = "Cumulative Capacity Charge (mAh)"
+STREAM_ACCU_CHARGE_ENERGY = "Cumulative Energy Charge (Wh)"
+STREAM_ACCU_DISCHARGE_CAP = "Cumulative Capacity Discharge (mAh)"
+STREAM_ACCU_DISCHARGE_ENERGY = "Cumulative Energy Discharge (Wh)"
+

--- a/custom_components/ecoflow_cloud/devices/internal/delta2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta2_max.py
@@ -8,13 +8,19 @@ from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
 from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
     CyclesSensorEntity, \
     InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, InMilliampSensorEntity, \
-    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
+    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity, \
+    CumulativeCapacitySensorEntity, EnergySensorEntity
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
 class Delta2Max(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
+            CumulativeCapacitySensorEntity(client, self, "bms_bmsInfo.accuChgCap", const.ACCU_CHARGE_CAP, False),
+            EnergySensorEntity(client, self, "bms_bmsInfo.accuChgEnergy", const.ACCU_CHARGE_ENERGY),
+            CumulativeCapacitySensorEntity(client, self, "bms_bmsInfo.accuDsgCap", const.ACCU_DISCHARGE_CAP, False),
+            EnergySensorEntity(client, self, "bms_bmsInfo.accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY),
+
             LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
             .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
             .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -10,13 +10,13 @@ class StreamAC(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             # "accuChgCap": 198511,
-            CumulativeCapacitySensorEntity(client, self, "accuChgCap", const.STREAM_ACCU_CHARGE_CAP, False),
+            CumulativeCapacitySensorEntity(client, self, "accuChgCap", const.ACCU_CHARGE_CAP, False),
             # "accuChgEnergy": 3992,
-            EnergySensorEntity(client, self, "accuChgEnergy", const.STREAM_ACCU_CHARGE_ENERGY),
+            EnergySensorEntity(client, self, "accuChgEnergy", const.ACCU_CHARGE_ENERGY),
             # "accuDsgCap": 184094,
-            CumulativeCapacitySensorEntity(client, self, "accuDsgCap", const.STREAM_ACCU_DISCHARGE_CAP, False),
+            CumulativeCapacitySensorEntity(client, self, "accuDsgCap", const.ACCU_DISCHARGE_CAP, False),
             # "accuDsgEnergy": 3646,
-            EnergySensorEntity(client, self, "accuDsgEnergy", const.STREAM_ACCU_DISCHARGE_ENERGY),
+            EnergySensorEntity(client, self, "accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY),
             # "actSoc": 46.0,
             # "amp": 44671,
             # "backupReverseSoc": 5,

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -4,15 +4,19 @@ from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumbe
     BaseSelectEntity
 from custom_components.ecoflow_cloud.sensor import WattsSensorEntity,LevelSensorEntity,CapacitySensorEntity, \
     InWattsSensorEntity,OutWattsSensorEntity, RemainSensorEntity, MilliVoltSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity
+    CyclesSensorEntity, EnergySensorEntity, CumulativeCapacitySensorEntity
 
 class StreamAC(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             # "accuChgCap": 198511,
+            CumulativeCapacitySensorEntity(client, self, "accuChgCap", const.STREAM_ACCU_CHARGE_CAP, False),
             # "accuChgEnergy": 3992,
+            EnergySensorEntity(client, self, "accuChgEnergy", const.STREAM_ACCU_CHARGE_ENERGY),
             # "accuDsgCap": 184094,
+            CumulativeCapacitySensorEntity(client, self, "accuDsgCap", const.STREAM_ACCU_DISCHARGE_CAP, False),
             # "accuDsgEnergy": 3646,
+            EnergySensorEntity(client, self, "accuDsgEnergy", const.STREAM_ACCU_DISCHARGE_ENERGY),
             # "actSoc": 46.0,
             # "amp": 44671,
             # "backupReverseSoc": 5,

--- a/custom_components/ecoflow_cloud/devices/public/data_bridge.py
+++ b/custom_components/ecoflow_cloud/devices/public/data_bridge.py
@@ -7,6 +7,7 @@ plain_to_status: dict[str, str] = {
     "mppt": "mpptStatus",
     "bms_emsStatus": "emsStatus",
     "bms_bmsStatus": "bmsStatus",
+    "bms_bmsInfo": "bmsInfo",
     "inv": "invStatus",
     "bms_slave": "bmsSlaveStatus",
     "bms_slave_bmsSlaveStatus_1": "bmsSlaveStatus_1",

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -259,16 +259,19 @@ class EnergySensorEntity(BaseSensorEntity):
         else:
             return False
 
-class CumulativeCapacitySensorEntity(EnergySensorEntity):
-    _attr_device_class = None
-    _attr_native_unit_of_measurement = "mAh"
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-
-
 class CapacitySensorEntity(BaseSensorEntity):
     _attr_native_unit_of_measurement = "mAh"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
+class CumulativeCapacitySensorEntity(CapacitySensorEntity):
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def _update_value(self, val: Any) -> bool:
+        ival = int(val)
+        if ival > 0:
+            return super()._update_value(ival)
+        else:
+            return False
 
 class DeciwattsSensorEntity(WattsSensorEntity):
     def _update_value(self, val: Any) -> bool:

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -98,7 +98,7 @@ class LevelSensorEntity(BaseSensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
 
 
-class RemainSensorEntity(BaseSensorEntity):
+class   RemainSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -258,6 +258,11 @@ class EnergySensorEntity(BaseSensorEntity):
             return super()._update_value(ival)
         else:
             return False
+
+class CumulativeCapacitySensorEntity(EnergySensorEntity):
+    _attr_device_class = None
+    _attr_native_unit_of_measurement = "mAh"
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
 
 class CapacitySensorEntity(BaseSensorEntity):

--- a/docs/Contribution.md
+++ b/docs/Contribution.md
@@ -37,5 +37,6 @@ After you finished your main work we recommend to run the task `Generate Docs`:
 1. Press `STRG` + `SHIFT` + `P`
 1. Select `Tasks: Run Task`
 1. Select `Generate Docs`
+1. Replace the paragraph `Current state` in `README.md` with `summary.md` content
 
 This will update the device documentation.

--- a/docs/devices/DELTA_2_MAX.md
+++ b/docs/devices/DELTA_2_MAX.md
@@ -1,6 +1,10 @@
 ## DELTA_2_MAX
 
 *Sensors*
+- Cumulative Capacity Charge (mAh) (`bms_bmsInfo.accuChgCap`)   _(disabled)_
+- Cumulative Energy Charge (Wh) (`bms_bmsInfo.accuChgEnergy`)
+- Cumulative Capacity Discharge (mAh) (`bms_bmsInfo.accuDsgCap`)   _(disabled)_
+- Cumulative Energy Discharge (Wh) (`bms_bmsInfo.accuDsgEnergy`)
 - Main Battery Level (`bms_bmsStatus.soc`)
 - Main Design Capacity (`bms_bmsStatus.designCap`)   _(disabled)_
 - Main Full Capacity (`bms_bmsStatus.fullCap`)   _(disabled)_

--- a/docs/devices/DELTA_2_Max-Public.md
+++ b/docs/devices/DELTA_2_Max-Public.md
@@ -1,6 +1,10 @@
 ## DELTA_2_Max
 
 *Sensors*
+- Cumulative Capacity Charge (mAh) (`bms_bmsInfo.accuChgCap`)   _(disabled)_
+- Cumulative Energy Charge (Wh) (`bms_bmsInfo.accuChgEnergy`)
+- Cumulative Capacity Discharge (mAh) (`bms_bmsInfo.accuDsgCap`)   _(disabled)_
+- Cumulative Energy Discharge (Wh) (`bms_bmsInfo.accuDsgEnergy`)
 - Main Battery Level (`bms_bmsStatus.soc`)
 - Main Design Capacity (`bms_bmsStatus.designCap`)   _(disabled)_
 - Main Full Capacity (`bms_bmsStatus.fullCap`)   _(disabled)_

--- a/docs/devices/STREAM_AC.md
+++ b/docs/devices/STREAM_AC.md
@@ -1,6 +1,10 @@
 ## STREAM_AC
 
 *Sensors*
+- Cumulative Capacity Charge (mAh) (`accuChgCap`)   _(disabled)_
+- Cumulative Energy Charge (Wh) (`accuChgEnergy`)
+- Cumulative Capacity Discharge (mAh) (`accuDsgCap`)   _(disabled)_
+- Cumulative Energy Discharge (Wh) (`accuDsgEnergy`)
 - Charge Remaining Time (`bmsChgRemTime`)   _(disabled)_
 - Discharge Remaining Time (`bmsDsgRemTime`)   _(disabled)_
 - Cycles (`cycles`)

--- a/docs/devices/STREAM_ULTRA.md
+++ b/docs/devices/STREAM_ULTRA.md
@@ -1,6 +1,10 @@
 ## STREAM_ULTRA
 
 *Sensors*
+- Cumulative Capacity Charge (mAh) (`accuChgCap`)   _(disabled)_
+- Cumulative Energy Charge (Wh) (`accuChgEnergy`)
+- Cumulative Capacity Discharge (mAh) (`accuDsgCap`)   _(disabled)_
+- Cumulative Energy Discharge (Wh) (`accuDsgEnergy`)
 - Charge Remaining Time (`bmsChgRemTime`)   _(disabled)_
 - Discharge Remaining Time (`bmsDsgRemTime`)   _(disabled)_
 - Cycles (`cycles`)

--- a/docs/devices/Stream_AC-Public.md
+++ b/docs/devices/Stream_AC-Public.md
@@ -1,6 +1,10 @@
 ## Stream_AC
 
 *Sensors*
+- Cumulative Capacity Charge (mAh) (`accuChgCap`)   _(disabled)_
+- Cumulative Energy Charge (Wh) (`accuChgEnergy`)
+- Cumulative Capacity Discharge (mAh) (`accuDsgCap`)   _(disabled)_
+- Cumulative Energy Discharge (Wh) (`accuDsgEnergy`)
 - Charge Remaining Time (`bmsChgRemTime`)   _(disabled)_
 - Discharge Remaining Time (`bmsDsgRemTime`)   _(disabled)_
 - Cycles (`cycles`)

--- a/docs/devices/Stream_Ultra-Public.md
+++ b/docs/devices/Stream_Ultra-Public.md
@@ -1,6 +1,10 @@
 ## Stream_Ultra
 
 *Sensors*
+- Cumulative Capacity Charge (mAh) (`accuChgCap`)   _(disabled)_
+- Cumulative Energy Charge (Wh) (`accuChgEnergy`)
+- Cumulative Capacity Discharge (mAh) (`accuDsgCap`)   _(disabled)_
+- Cumulative Energy Discharge (Wh) (`accuDsgEnergy`)
 - Charge Remaining Time (`bmsChgRemTime`)   _(disabled)_
 - Discharge Remaining Time (`bmsDsgRemTime`)   _(disabled)_
 - Cycles (`cycles`)

--- a/docs/gen.py
+++ b/docs/gen.py
@@ -195,44 +195,44 @@ def render_device_summary(device: BaseDevice, brief: bool = False) -> str:
 
 
 def render_brief_summary():
+    content_summary = "## Current state\n"
     for dt, dev in devices.items():
-        if dt != "DIAGNOSTIC":
+        if not dt.upper().startswith("DIAGNOSTIC"):
             content = ""
             real_devices = get_devices(dt, dev)
             for device in real_devices:
                 if len(real_devices) > 1:
                     content = content + f"\n### {device.device_data.device_type}\n"
                 content = content + render_device_summary(device, True)
-            print(
-                "<details><summary> %s <i>(%s)</i> </summary>"
-                % (dt, device_summary(real_devices))
-            )
-            print("<p>")
-            print(content)
-            print("</p></details>")
-            print()
+            content_summary+="<details><summary> %s <i>(%s)</i> </summary>" % (dt, device_summary(real_devices))
+            content_summary+="\n<p>\n"
+            content_summary+=content
+            content_summary+="\n</p></details>\n"
+            content_summary+= "\n"
 
     for dt, dev in device_by_product.items():
-        if dt != "DIAGNOSTIC":
+        if not dt.upper().startswith("DIAGNOSTIC"):
             content = ""
             real_devices = get_devices(dt, dev)
             for device in real_devices:
                 if len(real_devices) > 1:
                     content = content + f"\n### {device.device_data.device_type}\n"
                 content = content + render_device_summary(device, True)
-            print(
-                "<details><summary> %s (API) <i>(%s)</i> </summary>"
-                % (dt, device_summary(real_devices))
-            )
-            print("<p>")
-            print(content)
-            print("</p></details>")
-            print()
+            content_summary+="<details><summary> %s (API) <i>(%s)</i> </summary>" % (dt, device_summary(real_devices))
+
+            content_summary+="\n<p>\n"
+            content_summary +=content
+            content_summary+="\n</p></details>\n"
+            content_summary+="\n"
+    print(content_summary)
+    with open("summary.md" , "w+") as f_summary:
+        f_summary.write(content_summary)
+        f_summary.write("\n")
 
 
 def update_full_summary():
     for dt, dev in devices.items():
-        if dt != "DIAGNOSTIC":
+        if not dt.upper().startswith("DIAGNOSTIC"):
             content = ""
             real_devices = get_devices(dt, dev)
             for device in real_devices:
@@ -247,7 +247,7 @@ def update_full_summary():
             print("- [%s](devices/%s.md)" % (dt, dt))
 
     for dt, dev in device_by_product.items():
-        if dt != "DIAGNOSTIC":
+        if not dt.upper().startswith("DIAGNOSTIC"):
             content = ""
             real_devices = get_devices(dt, dev)
             for device in real_devices:

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1,25 +1,4 @@
-# EcoFlow Cloud Integration for Home Assistant
-[![GitHub release](https://img.shields.io/github/release/tolwi/hassio-ecoflow-cloud?include_prereleases=&sort=semver&color=blue)](https://github.com/tolwi/hassio-ecoflow-cloud/releases/)
-[![issues - hassio-ecoflow-cloud](https://img.shields.io/github/issues/tolwi/hassio-ecoflow-cloud)](https://github.com/tolwi/hassio-ecoflow-cloud/issues)
-[![GH-code-size](https://img.shields.io/github/languages/code-size/tolwi/hassio-ecoflow-cloud?color=red)](https://github.com/tolwi/hassio-ecoflow-cloud)
-[![GH-last-commit](https://img.shields.io/github/last-commit/tolwi/hassio-ecoflow-cloud?style=flat-square)](https://github.com/tolwi/hassio-ecoflow-cloud/commits/main)
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-[![HACS validation](https://github.com/tolwi/hassio-ecoflow-cloud/workflows/Validate%20with%20hassfest%20and%20HACS/badge.svg)](https://github.com/tolwi/hassio-ecoflow-cloud/actions?query=workflow:"Validate%20with%20hassfest%20and%20HACS")
-
-Inspired by [hassio-ecoflow](https://github.com/vwt12eh8/hassio-ecoflow) and [ecoflow-mqtt-prometheus-exporter](https://github.com/berezhinskiy/ecoflow-mqtt-prometheus-exporter) this integration uses EcoFlow MQTT Broker `mqtt.ecoflow.com` to monitor and control the device.
-
-## Installation
-
-- Install as a custom repository via HACS
-- Manually download and extract to the custom_components directory
-
-Once installed, use Add Integration -> Ecoflow Cloud.
-
-## Disclaimers
-
-⚠️ Originally developed for personal use without a goal to cover all available device attributes
-
-## Current state
+## Current state :
 <details><summary> DELTA_2 <i>(sensors: 45, switches: 8, sliders: 6, selects: 5)</i> </summary>
 <p>
 
@@ -2040,5 +2019,4 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-## How to
-- [Add/update device](docs/integration.md)
+

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1,4 +1,4 @@
-## Current state :
+## Current state
 <details><summary> DELTA_2 <i>(sensors: 45, switches: 8, sliders: 6, selects: 5)</i> </summary>
 <p>
 
@@ -977,10 +977,14 @@
 
 </p></details>
 
-<details><summary> STREAM_AC <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> STREAM_AC <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles
@@ -1025,10 +1029,14 @@
 
 </p></details>
 
-<details><summary> STREAM_ULTRA <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> STREAM_ULTRA <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles
@@ -1923,10 +1931,14 @@
 
 </p></details>
 
-<details><summary> Stream AC (API) <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> Stream AC (API) <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles
@@ -1971,10 +1983,14 @@
 
 </p></details>
 
-<details><summary> Stream Ultra (API) <i>(sensors: 35, switches: 0, sliders: 0, selects: 0)</i> </summary>
+<details><summary> Stream Ultra (API) <i>(sensors: 39, switches: 0, sliders: 0, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Charge Remaining Time  _(disabled)_
 - Discharge Remaining Time  _(disabled)_
 - Cycles

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -681,10 +681,14 @@
 
 </p></details>
 
-<details><summary> DELTA_2_MAX <i>(sensors: 67, switches: 7, sliders: 6, selects: 3)</i> </summary>
+<details><summary> DELTA_2_MAX <i>(sensors: 71, switches: 7, sliders: 6, selects: 3)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Main Battery Level
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_
@@ -1258,10 +1262,14 @@
 
 </p></details>
 
-<details><summary> DELTA 2 Max (API) <i>(sensors: 67, switches: 7, sliders: 6, selects: 3)</i> </summary>
+<details><summary> DELTA 2 Max (API) <i>(sensors: 71, switches: 7, sliders: 6, selects: 3)</i> </summary>
 <p>
 
 *Sensors*
+- Cumulative Capacity Charge (mAh)  _(disabled)_
+- Cumulative Energy Charge (Wh)
+- Cumulative Capacity Discharge (mAh)  _(disabled)_
+- Cumulative Energy Discharge (Wh)
 - Main Battery Level
 - Main Design Capacity  _(disabled)_
 - Main Full Capacity  _(disabled)_


### PR DESCRIPTION
Devices : Delta 2 Max, Stream AC, Stream Ultra :
- add cumulative charge (mAh and Wh)
- add cumulative discharge (mAh and Wh)

Usefull to add it into Energy board

(this PR has also https://github.com/tolwi/hassio-ecoflow-cloud/pull/489 content)