### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/ecoflow_cloud/manifest.json
+++ b/custom_components/ecoflow_cloud/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tolwi/hassio-ecoflow-cloud/issues",
   "requirements": [
-    "paho-mqtt>=1.6.1",
+    "paho-mqtt>=2.1.0",
     "protobuf>=4.23.0",
     "jsonpath-ng>=1.7.0"
   ],


### PR DESCRIPTION
Upgrade to new version of package because with the HA version 2025.07 the installation is not working

ecoflow cloud home assistant j'ai ca Unable to install package paho-mqtt==1.6.1: × No solution found when resolving dependencies: ╰─▶ Because you require paho-mqtt==1.6.1 and paho-mqtt==2.1.0, we can conclude that your requirements are unsatisfiable.


