### PR TITLE
FIX powerstream limit (600 -> 800)

### DIFF
--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -231,7 +231,7 @@ class PowerStream(BaseDevice):
                 "20_1.permanentWatts",
                 "Custom load power settings",
                 0,
-                600,
+                800,
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "WN511_SET_PERMANENT_WATTS_PACK",


### PR DESCRIPTION
To avoid this error : 
Error executing script. Error for call_service at pos 2: Value 621.0 for number.powerstream_xxx_custom_load_power_settings is outside valid range 0 - 600

Fix max value as it was before last release : 800W