### PR TITLE
Add controls for Max battery charge level and Min battery charge level in internal powerstream.py

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -10,6 +10,7 @@ from homeassistant.util import dt
 
 from custom_components.ecoflow_cloud.devices import const
 from custom_components.ecoflow_cloud.select import PowerDictSelectEntity
+from custom_components.ecoflow_cloud.number import MaxBatteryLevelEntity, MinBatteryLevelEntity
 
 from ...devices import BaseDevice
 from ...devices.internal.proto.support import (
@@ -277,7 +278,34 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
 
     @override
     def numbers(self, client: EcoflowApiClient) -> Sequence[NumberEntity]:
-        return []
+        return [
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "20_1.upperLimit",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: build_command(
+                    device_sn=self.device_info.sn,
+                    command=Command.WN511_SET_BAT_UPPER_PACK,
+                    payload=powerstream.BatUpperPack(upper_limit=value),
+                ), 
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "20_1.lowerLimit",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: build_command(
+                    device_sn=self.device_info.sn,
+                    command=Command.WN511_SET_BAT_LOWER_PACK,
+                    payload=powerstream.BatLowerPack(lower_limit=value),
+                ),
+            ),
+        ]
 
     @override
     def _prepare_data(self, raw_data: bytes) -> dict[str, Any]:


### PR DESCRIPTION
Hi

Thanks for this awesome plugin. 

I have made a small change to have the Internal Powerstream device show to number controls:
- Max battery charge level 
- Min battery charge level

Why:

There is an issue with Powerstream where the settings get reset every day. Example:
https://old.reddit.com/r/Ecoflow_community/comments/1ljajkj/ecoflow_app_settings_are_reseting_every_day/

https://old.reddit.com/r/Ecoflow_community/comments/1m70qxy/powerstream_keeps_resetting_chargedischarge_limit/

With the two number controls above, one can easily add a script to get around the problem and have Home Assistant set the desired values when a change is detected.

<img width="1668" height="1435" alt="image" src="https://github.com/user-attachments/assets/30b080de-73d9-449a-8c2c-4b396bcac3f2" />

