### PR TITLE
Fix "KeyError: 'status'" when MQTT is dropped and re-established.

### DIFF
--- a/custom_components/ecoflow_cloud/devices/data_holder.py
+++ b/custom_components/ecoflow_cloud/devices/data_holder.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Callable
 from typing import Any, TypeVar
 
+import json
 import jsonpath_ng.ext as jp
 from homeassistant.util import dt
 
@@ -91,6 +92,9 @@ class EcoflowDataHolder:
         self.params_time = dt.utcnow()
 
     def update_status(self, raw: dict[str, Any]):
+        if raw is None or "params" not in raw or "status" not in raw["params"]:
+            _LOGGER.warning("No status in raw: %s", json.dumps(raw))
+            return
         self.status.update({"status": int(raw["params"]["status"])})
         self.status_time = dt.utcnow()
 

--- a/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
+++ b/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
@@ -185,6 +185,10 @@ class SmartHomePanel2(BaseDevice):
             for k, v in res["param"].items():
                 new_params[f"{k}"] = v
 
+        if "params" in res:
+            for k, v in res["params"].items():
+                new_params[f"{k}"] = v
+
         for k, v in res.items():
             if k != "param" and k != "params":
                 new_params[f"{k}"] = v


### PR DESCRIPTION
Fixes #589 where an MQTT disconnection while using the public SHP2 integration would exception when the MQTT connection was restored. This would cause the SHP2 and any other devices using the same MQTT connection to stop updating and stop processing any pushed updates.

### Analysis

The SHP2 integration rewrites the messages that are received in the `_prepare_data()` method. The code was only handling `param` and not `params`. I'm honestly not sure if/when `param` is used, but the code now handles merging in both `param` and `params`.

So a message received of:

```
{"id": "084863526", "params": {"status": 0}, "timestamp": 1759073097161, "version": "1.0"}
```

Was being re-written as:

```
{"params": {"id": "084863526", "timestamp": 1759073097161, "version": "1.0"}, "raw_data": {"id": "084863526", "params": {"status": 0}, "timestamp": 1759073097161, "version": "1.0"}}
```

This was causing the `update_status()` in `data_holder` to error with `KeyError: 'status'` when it attempted to access `raw["params"]["status"]`.