### PR TITLE
fix: correct inverted logic in SmartMeter.update_data()

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/smart_meter.py
+++ b/custom_components/ecoflow_cloud/devices/internal/smart_meter.py
@@ -332,14 +332,18 @@ class SmartMeter(BaseDevice):
         ]
 
     def update_data(self, raw_data: bytes, data_type: str) -> bool:
-        if data_type not in [
+        # Process protobuf data for Smart Meter topics
+        if data_type in [
             self.device_info.data_topic,
             self.device_info.set_reply_topic,
             self.device_info.get_reply_topic,
             self.device_info.status_topic,
         ]:
-            super().update_data(raw_data, data_type)
-        return True
+            raw = self._prepare_data(raw_data)
+            self.data.update_data(raw)
+            return True
+        # For other topics, use the base class implementation
+        return super().update_data(raw_data, data_type)
 
     @override
     def _prepare_data(self, raw_data: bytes) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #647

The [update_data](cci:1://file:///Users/benediktmerkel/Documents/06_Programmierung/core/config/custom_components/hassio-ecoflow-cloud-repo/custom_components/ecoflow_cloud/devices/__init__.py:164:4-185:19) method was not processing protobuf data for Smart Meter topics. 
The condition was inverted, causing it to call `super().update_data()` only for 
non-Smart Meter topics while ignoring the actual Smart Meter data.