### PR TITLE
Add binary_sensor platform so the new binary_sensors lists load for devices

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -17,11 +17,12 @@ ECOFLOW_DOMAIN = "ecoflow_cloud"
 CONFIG_VERSION = 9
 
 _PLATFORMS = {
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
-    Platform.BUTTON,
 }
 
 ATTR_STATUS_SN = "SN"


### PR DESCRIPTION
Commit eadd9773f1cc751c8433679638672e0c783099d2 introduced the `binary_senors()` list as part of the device configurations. However, the `MiscBinarySensorEntity` items are not loading.

Adding Platform.BINARY_SENSOR gets them to auto-load.