### PR TITLE
PowerOcean: Adding three sensors

### DIFF
--- a/custom_components/ecoflow_cloud/devices/public/powerocean.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerocean.py
@@ -66,6 +66,9 @@ class PowerOcean(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
         sensors: list[SensorEntity] = [
             LevelSensorEntity(client, self, "96_8.bpSoc", "bpSoc"),
+            WattsSensorEntity(client, self, "96_8.bpPwr", "bpPwr"),
+            WattsSensorEntity(client, self, "96_8.mpptPwr", "mpptPwr"),
+            WattsSensorEntity(client, self, "96_8.sysGridPwr", "sysGridPwr"),
             VoltSensorEntity(client, self, "96_1.pcsAPhase.vol", "pcsAPhase.vol"),
             AmpSensorEntity(client, self, "96_1.pcsAPhase.amp", "pcsAPhase.amp"),
             WattsSensorEntity(client, self, "96_1.pcsAPhase.actPwr", "pcsAPhase.actPwr"),


### PR DESCRIPTION
With these three sensors the full house energy flow can be monitored. From sum of PV (mpptPwr), house total net power (sysGridPwr) to battery power used (bpPwr).

this is my first pullrequest ever :)