### PR TITLE
Keep last public API sensor values while offline

### DIFF
--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -144,7 +144,10 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
     def _handle_coordinator_update(self) -> None:
         if self.coordinator.data.changed:
             self._updated(self.coordinator.data.data_holder.params)
-        elif not self.coordinator.data.data_holder.online:  # Device is offline
+        elif (
+            not self.coordinator.data.data_holder.online
+            and not self._device.device_info.public_api
+        ):  # Keep the last public API reading instead of flapping to sensor defaults.
             # Reset sensors that should reset to default values
             if isinstance(self, BaseSensorEntity) and self._attr_default_value is not None:
                 self._mqtt_key_expr.update(self.coordinator.data.data_holder.params, self._attr_default_value)


### PR DESCRIPTION
## Summary

This fixes public API sensor values flapping between their real reading and `0` when the device briefly appears offline or stops delivering fresh quota data.

## Problem

For public API devices, the integration can temporarily consider the device offline. When that happened, sensor entities with a default value were resetting themselves to that default, which commonly meant `0`.

That behavior is misleading for measurement entities:
- `0` is a real measurement
- it does not mean "no fresh data"
- dashboards and history end up showing false zeroes instead of preserving the last known reading

In practice this showed up as repeated flapping such as:

- real value
- `0`
- real value

## Root Cause

The public API data merge path already keeps prior values when a response omits fields. The visible zeroing was happening later in the entity layer, where offline handling reset sensor values to `_attr_default_value`.

## Change

This change keeps the existing reset-to-default behavior for non-public-api devices, but skips that reset for public API devices.

As a result:
- public API status entities still report `assume_offline` / `offline`
- public API measurement sensors keep their last known reading instead of being forced to `0`

## Why this is safer

For public API devices, a stale last-known value plus an offline status is more accurate than fabricating `0` readings during transient outages.

## Files

- `custom_components/ecoflow_cloud/entities/__init__.py`

## Verification

- Confirmed the zeroing path was in offline entity handling, not in the public API params merge
- Compiled the updated module successfully with `python -m compileall`