### PR TITLE
Stop scheduled status sensor logbook churn

### DIFF
--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -608,16 +608,11 @@ class QuotaScheduledStatusSensorEntity(QuotaStatusSensorEntity):
         quota_diff = dt.as_timestamp(dt.utcnow()) - dt.as_timestamp(self._quota_last_update)
         # if delay passed, reload quota
         if quota_diff > (self.assume_offline_period_sec):
-            self._attr_native_value = "updating"
             self._quota_last_update = dt.utcnow()
             self.hass.async_create_background_task(self._client.quota_all(self._device.device_info.sn), "get quota")
             self._attrs[ATTR_QUOTA_REQUESTS] = self._attrs[ATTR_QUOTA_REQUESTS] + 1
             _LOGGER.debug("Reload quota for device %s", self._device.device_info.sn)
             changed = True
-        else:
-            if self._attr_native_value == "updating":
-                changed = True
-            self._attr_native_value = "online"
         return changed
 
 


### PR DESCRIPTION
## Summary

This removes noisy `updating -> online` state transitions from the scheduled status sensor used for periodic quota refreshes.

## Problem

`QuotaScheduledStatusSensorEntity` was intentionally toggling its state to:
- `updating`
- then back to `online`

on each scheduled quota refresh.

That creates logbook/activity entries even though nothing meaningful changed from the user's perspective. In Home Assistant this can push actually relevant device activity further down the log.

## Change

The scheduled quota refresh still runs on the same cadence, and the quota request counter attribute still updates, but the entity no longer changes its state just to announce that a background refresh started.

This keeps the diagnostic behavior without generating extra activity-log noise.

## Expected Result

- scheduled quota polling still happens
- status still reflects real connectivity changes
- the activity log is no longer spammed by periodic informational transitions

## Files

- `custom_components/ecoflow_cloud/sensor.py`

## Verification

- Compiled the updated module successfully with `python -m compileall`