### PR TITLE
public: schedule quota fallback refresh for PowerStream and PowerOcean

### DIFF
--- a/custom_components/ecoflow_cloud/devices/public/powerocean.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerocean.py
@@ -18,9 +18,9 @@ from custom_components.ecoflow_cloud.sensor import (
     LevelSensorEntity,
     MilliVoltSensorEntity,
     MiscSensorEntity,
+    QuotaScheduledStatusSensorEntity,
     SolarAmpSensorEntity,
     SolarPowerSensorEntity,
-    StatusSensorEntity,
     TempSensorEntity,
     VoltSensorEntity,
     WattsSensorEntity,
@@ -93,7 +93,7 @@ class PowerOcean(BaseDevice):
         for index in range(1, battery_count + 1):
             sensors.extend(self._create_battery_sensors(client, index))
 
-        sensors.append(StatusSensorEntity(client, self))
+        sensors.append(self._status_sensor(client))
         return sensors
 
     def _determine_mppt_metadata(self) -> tuple[str, int]:
@@ -224,8 +224,9 @@ class PowerOcean(BaseDevice):
             params.update(flattened)
         return res
 
-    def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
-        return StatusSensorEntity(client, self)
+    def _status_sensor(self, client: EcoflowApiClient) -> QuotaScheduledStatusSensorEntity:
+        # Keep quota fallback active even while MQTT stream is sparse.
+        return QuotaScheduledStatusSensorEntity(client, self, 60)
 
     def _flatten_param_branch(self, prefix: str, value: Any, target: dict[str, Any]) -> None:
         if isinstance(value, dict):

--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -29,8 +29,8 @@ from custom_components.ecoflow_cloud.sensor import (
     LevelSensorEntity,
     MilliampSensorEntity,
     MiscSensorEntity,
+    QuotaScheduledStatusSensorEntity,
     RemainSensorEntity,
-    StatusSensorEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -193,5 +193,6 @@ class PowerStream(BaseDevice):
         res = to_plain(res)
         return res
 
-    def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
-        return StatusSensorEntity(client, self)
+    def _status_sensor(self, client: EcoflowApiClient) -> QuotaScheduledStatusSensorEntity:
+        # Keep quota fallback active even while MQTT stream is sparse.
+        return QuotaScheduledStatusSensorEntity(client, self, 60)


### PR DESCRIPTION
## Summary
- switch public `PowerStream` status sensor to `QuotaScheduledStatusSensorEntity` (60s)
- switch public `PowerOcean` status sensor to `QuotaScheduledStatusSensorEntity` (60s)
- keep changes minimal (no protocol/auth changes)

## Why
When MQTT updates become sparse/stale, these devices currently rely on passive updates.
This change triggers periodic `quota_all` fallback refresh to reduce stale values and improve recovery without changing the existing architecture.

## Scope
- `custom_components/ecoflow_cloud/devices/public/powerstream.py`
- `custom_components/ecoflow_cloud/devices/public/powerocean.py`

## Validation
- `python3 -m py_compile custom_components/ecoflow_cloud/devices/public/powerstream.py custom_components/ecoflow_cloud/devices/public/powerocean.py`
