### PR TITLE
Delta 3 Pro Updates to Solar in amp/ volts and Charge energy

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -108,10 +108,10 @@ class DeltaPro3(BaseInternalDevice):
             OutVoltDcSensorEntity(client, self, "pow_get_24v_vol", "24V DC Output Voltage"),
             InRawWattsSolarSensorEntity(client, self, "pow_get_pv_h", "Solar High Voltage Input Power"),
             InRawWattsSolarSensorEntity(client, self, "pow_get_pv_l", "Solar Low Voltage Input Power"),
-            InVoltSolarSensorEntity(client, self, "pow_get_pv_h_vol", "Solar HV Input Voltage"),
-            InVoltSolarSensorEntity(client, self, "pow_get_pv_l_vol", "Solar LV Input Voltage"),
-            InMilliampSolarSensorEntity(client, self, "pow_get_pv_h_amp", "Solar HV Input Current"),
-            InMilliampSolarSensorEntity(client, self, "pow_get_pv_l_amp", "Solar LV Input Current"),
+            VoltSensorEntity(client, self, "plug_in_info_pv_h_vol", "Solar HV Input Voltage"),
+            VoltSensorEntity(client, self, "plug_in_info_pv_l_vol", "Solar LV Input Voltage"),
+            AmpSensorEntity(client, self, "plug_in_info_pv_h_amp", "Solar HV Input Current"),
+            AmpSensorEntity(client, self, "plug_in_info_pv_l_amp", "Solar LV Input Current"),
             OutWattsSensorEntity(client, self, "pow_get_qcusb1", const.USB_QC_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pow_get_qcusb2", const.USB_QC_2_OUT_POWER),
             OutWattsSensorEntity(client, self, "pow_get_typec1", const.TYPEC_1_OUT_POWER),
@@ -126,8 +126,8 @@ class DeltaPro3(BaseInternalDevice):
             # Note: accuChgEnergy and accuDsgEnergy are in Wh, multiply by 0.001 for kWh display
             # These fields do not exist in DisplayPropertyUpload - they come from BMSHeartBeatReport
             # Using camelCase to match upstream pattern (see stream_ac.py)
-            InEnergySensorEntity(client, self, "accuChgEnergy", "Total Charge Energy"),
-            OutEnergySensorEntity(client, self, "accuDsgEnergy", "Total Discharge Energy"),
+            InEnergySensorEntity(client, self, "accu_chg_energy", "Total Charge Energy"),
+            OutEnergySensorEntity(client, self, "accu_dsg_energy", "Total Discharge Energy"),
             # Note: The following fields do not exist in any Delta Pro 3 protobuf messages:
             # - pow_in_sum_energy (Total Input Energy)
             # - pow_out_sum_energy (Total Output Energy)

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -407,6 +407,7 @@ class InAmpSensorEntity(AmpSensorEntity):
 
 class InRawAmpSolarSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:solar-power"
+    _attr_suggested_display_precision = 2
 
 class OutMilliampSensorEntity(MilliampSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -405,6 +405,8 @@ class InAmpSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:transmission-tower-import"
     _attr_suggested_display_precision = 2
 
+class InRawAmpSolarSensorEntity(AmpSensorEntity):
+    _attr_icon = "mdi:solar-power"
 
 class OutMilliampSensorEntity(MilliampSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"


### PR DESCRIPTION
### Summary

in 1.4.0 I updated 
accuChgEnergy -> accu_chg_energy
accuDsgEnergy -> accu_dsg_energy
pow_get_pv_h -> plug_in_info_pv_h_vol
pow_get_pv_l -> plug_in_info_pv_l_vol
pow_get_pv_h_vol -> plug_in_info_pv_h_amp
pow_get_pv_l_vol -> plug_in_info_pv_l_amp
to match mqtt variables

### Problem

with out these changes:
Solar HV Input Voltage
Solar LV Input Voltage
Solar HV Input Current
Solar LV Input Current
Total Charge Energy
Total Discharge Energy
Don't populate their data 

This is my first pull request, I think I did everything correctly and did my best to follow your naming convention in sensor.py

<img width="323" height="431" alt="image" src="https://github.com/user-attachments/assets/cae4f4e3-a2a9-43fd-a234-7ebb6bfa96d0" />
