### PR TITLE
Correct offline detection for Public API PowerStream Device

### DIFF
--- a/custom_components/ecoflow_cloud/api/public_api.py
+++ b/custom_components/ecoflow_cloud/api/public_api.py
@@ -79,22 +79,25 @@ class EcoflowPublicApiClient(EcoflowApiClient):
         return device
 
     async def quota_all(self, device_sn: str | None):
-        if not device_sn:
-            target_devices = list(self.devices)
-            # update all statuses
+        target_devices = [device_sn] if device_sn else list(self.devices)
+
+        # Always fetch the authoritative online status from the device list.
+        # The quota endpoint returns cached data even for offline devices, so we
+        # cannot infer online/offline from whether data is present.
+        online_by_sn: dict[str, bool] = {}
+        try:
             devices = await self.fetch_all_available_devices()
             for device in devices:
-                if device.sn in self.devices:
-                    status = device.status == 1
-                    self.devices[device.sn].data.add_data(PreparedData(status, None, None))
-        else:
-            target_devices = [device_sn]
+                online_by_sn[device.sn] = device.status == 1
+        except Exception as exception:
+            _LOGGER.error("Error fetching device list for status: %s", exception)
 
         for sn in target_devices:
+            is_online = online_by_sn.get(sn)  # None means device list fetch failed
             try:
                 raw = await self.call_api("/device/quota/all", {"sn": sn})
-                if "data" in raw:
-                    self.devices[sn].data.add_data(PreparedData(None, {"params": raw["data"]}, raw))
+                params = {"params": raw["data"]} if raw.get("data") and is_online else None
+                self.devices[sn].data.add_data(PreparedData(is_online, params, raw))
             except Exception as exception:
                 _LOGGER.error(exception, exc_info=True)
                 _LOGGER.error("Error retrieving %s", sn)

--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -31,6 +31,7 @@ from custom_components.ecoflow_cloud.sensor import (
     MiscSensorEntity,
     QuotaScheduledStatusSensorEntity,
     RemainSensorEntity,
+    StatusSensorEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -97,6 +98,7 @@ class PowerStream(BaseDevice):
             MiscSensorEntity(client, self, "20_1.wirelessWarnCode", "Wireless Warning Code", False),
             MiscSensorEntity(client, self, "20_1.invBrightness", "LED Brightness", False),
             MiscSensorEntity(client, self, "20_1.heartbeatFrequency", "Heartbeat Frequency", False),
+            StatusSensorEntity(client, self),
             self._status_sensor(client),
         ]
 

--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -31,7 +31,6 @@ from custom_components.ecoflow_cloud.sensor import (
     MiscSensorEntity,
     QuotaScheduledStatusSensorEntity,
     RemainSensorEntity,
-    StatusSensorEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,7 +97,6 @@ class PowerStream(BaseDevice):
             MiscSensorEntity(client, self, "20_1.wirelessWarnCode", "Wireless Warning Code", False),
             MiscSensorEntity(client, self, "20_1.invBrightness", "LED Brightness", False),
             MiscSensorEntity(client, self, "20_1.heartbeatFrequency", "Heartbeat Frequency", False),
-            StatusSensorEntity(client, self),
             self._status_sensor(client),
         ]
 

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -410,9 +410,11 @@ class InAmpSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:transmission-tower-import"
     _attr_suggested_display_precision = 2
 
+
 class InRawAmpSolarSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:solar-power"
     _attr_suggested_display_precision = 2
+
 
 class OutMilliampSensorEntity(MilliampSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"
@@ -513,7 +515,10 @@ class StatusSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):
         changed = self._actualize_status() or changed
 
         if changed:
-            self.coordinator.data.data_holder.online = self._online == _OnlineStatus.ONLINE
+            if self._online != _OnlineStatus.ASSUME_OFFLINE:
+                self.coordinator.data.data_holder.online = self._online == _OnlineStatus.ONLINE
+            # assume_offline: leave data_holder.online untouched to avoid
+            # resetting sensor values during transient API gaps
 
             if self._device.device_data.options.verbose_status_mode or self._online in {
                 _OnlineStatus.ONLINE,
@@ -762,4 +767,4 @@ class WattsDifferenceSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):
         if input_val is None or output_val is None or input_val is STATE_UNKNOWN or output_val is STATE_UNKNOWN:
             self._difference = None
             return
-        self._difference = float(output_val) - float(input_val)        
+        self._difference = float(output_val) - float(input_val)


### PR DESCRIPTION
_Transparency Note: This fix was mainly analyzed and implemented using AI (GitHub Copilot with Claude Sonnet)_

## Problem

Related changes after v1.3 affecting the public API / PowerStream:

- **Sensor values didn't reset to 0 when offline.** `/device/quota/all` returns cached data even for offline devices. The code passed this data unconditionally as `PreparedData(None, params, raw)`, which caused `data_holder` to set `online=True` on every quota poll — the offline reset path never triggered.

## Root cause

- `quota_all()` only fetched the authoritative device list (which has a real `online` field) at startup. Periodic per-device calls skipped it entirely, so online status was never updated after startup except via MQTT. Additionally `data_holder` unconditionally sets `online=True` whenever `params is not None`, so stale cached quota data always implied online.

## Changes

**`quota_all()` — always fetch authoritative online status**
Device list fetch is now unconditional. `PreparedData.online` is set from the device list result before processing quota data:

- Online + data present → `PreparedData(True, params, raw)`
- Offline → `PreparedData(False, None, raw)` — stale cache discarded
- Device list fetch failed → `PreparedData(None, None, raw)` — online status left untouched

**`sensor.py` — `assume_offline` no longer triggers value reset**
Only `ONLINE`/`OFFLINE` now write to `data_holder.online`. `ASSUME_OFFLINE` leaves it untouched — the status entity shows the warning, but sensor values hold their last real reading until a confirmed offline.

| Condition | `Status` | Sensor values |
|---|---|---|
| Device online | `online` | real values |
| API silent < 300 s | `assume_offline` | hold last value |
| API silent > 900 s or device list says offline | `offline` | reset to 0 |
| Device list fetch fails | unchanged | unchanged |