### PR TITLE
feat(delta3_1500): add Grid Bypass switch via bypassBan

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -268,6 +268,7 @@ XBOOST_ENABLED = "X-Boost Enabled"
 AC_ALWAYS_ENABLED = "AC Always On"
 PV_PRIO = "Prio Solar Charging"
 BP_ENABLED = "Backup Reserve Enabled"
+GRID_BYPASS = "Grid Bypass"
 AUTO_FAN_SPEED = "Auto Fan Speed"
 AC_SLOW_CHARGE = "AC Slow Charging"
 

--- a/custom_components/ecoflow_cloud/devices/internal/delta3_1500.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_1500.py
@@ -27,7 +27,11 @@ from custom_components.ecoflow_cloud.sensor import (
     StatusSensorEntity,
     TempSensorEntity,
 )
-from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
+from custom_components.ecoflow_cloud.switch import (
+    BeeperEntity,
+    BypassBanSwitch,
+    EnabledEntity,
+)
 
 
 class Delta31500(BaseInternalDevice):
@@ -221,6 +225,19 @@ class Delta31500(BaseInternalDevice):
                     "operateType": "watthConfig",
                     "params": {"bpPowerSoc": value * 50, "minChgSoc": 0, "isConfig": value, "minDsgSoc": 0},
                 },
+            ),
+            BypassBanSwitch(
+                client,
+                self,
+                "pd.reserved",
+                const.GRID_BYPASS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "bypassBan",
+                    "params": {"banBypassEn": int(value)},
+                },
+                enableValue=1,
+                disableValue=0,
             ),
         ]
 

--- a/custom_components/ecoflow_cloud/switch.py
+++ b/custom_components/ecoflow_cloud/switch.py
@@ -202,3 +202,27 @@ class InvertedBeeperEntity(EnabledEntity):
             return "mdi:volume-high"
         else:
             return "mdi:volume-mute"
+
+
+class BypassBanSwitch(EnabledEntity):
+    """Grid-bypass switch controlled by the EcoFlow ``bypassBan`` command.
+
+    Used by devices that do not publish the bypass flag as a scalar in
+    push telemetry, but mirror it as index ``[1]`` of an array-valued
+    quota field (e.g. ``pd.reserved`` on DELTA 3 1500). The second
+    element of the array is interpreted as the bypass state:
+
+      0 -> grid bypass enabled  (battery charges from AC input)
+      1 -> grid bypass disabled (battery runs standalone, no charging)
+
+    When the switch is ON, the grid bypass is disabled (matching the
+    "Disable grid bypass" toggle in the EcoFlow mobile app).
+    """
+
+    def _update_value(self, val: Any) -> bool:
+        if isinstance(val, list) and len(val) >= 2:
+            new_state = val[1] == 1
+            if self._attr_is_on != new_state:
+                self._attr_is_on = new_state
+                return True
+        return False


### PR DESCRIPTION
## Summary

Adds a new `switch.delta3_1500_grid_bypass` entity to the DELTA 3 1500 device class. It mirrors the "Disable grid bypass" toggle available in the EcoFlow mobile app for this device:

- **ON** → grid bypass disabled → battery runs standalone, no charging from AC in
- **OFF** → grid bypass enabled → battery charges normally from the AC input

This is the missing piece to implement solar-surplus charging scenarios for DELTA 3 1500 from Home Assistant without pulling from the grid when PV is insufficient (the integration's native `AC Charging Power` slider has a 200 W lower bound, so it cannot fully stop grid draw on its own).

## Why this, and not `chgPauseFlag`?

The DELTA 2 family uses `{"moduleType": 5, "operateType": "acChgCfg", "params": {"chgWatts": N, "chgPauseFlag": F}}` with `chgPauseFlag` as a pause-charging toggle (see #34 and #159). I tested this path on a DELTA 3 1500 (`D361…` serial): the device accepts the command (no error, `ack=0`) but **`chgPauseFlag` is silently ignored** — AC in power does not drop and `battery_charging_state` stays `charging`. Reproducible in both `chgPauseFlag=0` and `chgPauseFlag=1` states.

The EcoFlow Android app, on the same device, uses a completely different command for its grid-bypass toggle. I captured it via the integration's own debug MQTT logs (after enabling `debug` for `custom_components.ecoflow_cloud.api.ecoflow_mqtt` and toggling "Disable grid bypass" in the app):

```json
{"from":"Android","moduleType":1,"operateType":"bypassBan","params":{"banBypassEn":1},"version":"1.0"}
```

The device acks with `{"code":"0","data":{"ack":0}}`. Sending this command from the integration produces the expected effect: `sensor.delta_3_1500_ac_in_power` drops to only the AC passthrough load (~115 W in my test setup), charging stops, and AC out keeps powering connected devices from the battery. The opposite command `{"banBypassEn": 0}` restores grid charging.

## State tracking

DELTA 3 1500 does not publish `banBypassEn` directly as a scalar key in push telemetry, so a naive switch using that as mqtt_key would remain `unknown`. However, the device mirrors the bypass state in `pd.reserved[1]`:

- `pd.reserved[1] == 0` right after `banBypassEn=0` (grid bypass enabled)
- `pd.reserved[1] == 1` right after `banBypassEn=1` (grid bypass disabled)

This was verified reproducibly across several toggles from both the app and the integration. The new `BypassBanSwitch` subclass reads `pd.reserved` as its `mqtt_key` and interprets index `[1]` as the state. This avoids the need for assumed-state or `RestoreEntity`, and correctly reflects reality if the command fails (the device simply does not update `pd.reserved`).

Using `pd.reserved` as the state field is admittedly not ideal — it's a vendor-reserved slot — but empirically it's the only place in push telemetry where the bypass state is exposed. If someone identifies a better scalar key, the subclass can be updated without breaking the device definition.

## Code structure

Following the existing patterns in this repo, the change is split across three files:

1. **`custom_components/ecoflow_cloud/devices/const.py`** — adds `GRID_BYPASS = "Grid Bypass"` alongside the other switch friendly-name constants.

2. **`custom_components/ecoflow_cloud/switch.py`** — adds `class BypassBanSwitch(EnabledEntity)` as a module-level reusable subclass, next to the other specialized switches (`BeeperEntity`, `BitMaskEnableEntity`, `FanModeEntity`, `InvertedBeeperEntity`). The class overrides `_update_value` to read index `[1]` from an array-valued mqtt_key.

3. **`custom_components/ecoflow_cloud/devices/internal/delta3_1500.py`** — imports the new class, and appends a `BypassBanSwitch(...)` entry to the list returned by `switches()` using `const.GRID_BYPASS` as the title and the MQTT command lambda shown above. `enableValue=1, disableValue=0` so the switch semantics match the EcoFlow app (ON = bypass disabled = no grid charging).

## Scope

Only DELTA 3 1500. I have not tested `bypassBan`/`banBypassEn` on:

- DELTA 2 / DELTA 2 Max (no hardware available)
- The original protobuf-based DELTA 3 (`P231…` series) — uses a completely different command transport (protobuf `Delta3SetCommand`), would require separate reverse-engineering
- Other devices

A follow-up PR can port the same approach to DELTA 2 if someone confirms the command shape and a suitable state field on that device.

## Testing

Verified on the firmware currently shipped with hardware SN `D361…`:

1. **Baseline**: `sensor.delta_3_1500_ac_in_power ≈ 440 W` (115 W AC passthrough to connected loads + ~325 W charging), slider `AC Charging Power = 300 W`.
2. `switch.turn_on switch.delta3_1500_grid_bypass` → within ~1 s the device publishes `pd.reserved=[1,1]`, switch state goes `on`, `ac_in_power` drops to ~115 W (passthrough only), `ac_out_power` unchanged (115 W), `battery_charging_state` stops.
3. `switch.turn_off switch.delta3_1500_grid_bypass` → device publishes `pd.reserved=[1,0]`, switch state goes `off`, charging resumes at the configured slider value.
4. Same behavior observed toggling from the EcoFlow mobile app — both paths converge on the same `pd.reserved[1]` state field.

No regressions observed on the other 68 DELTA 3 1500 entities.

## Related issues

- #34 — DELTA 2 `chgPauseFlag` discussion (different command path, not applicable to DELTA 3 1500)
- #159 — Delta Max `acChgCfg` range (reference for the DELTA 2 family command shape)
