### PR TITLE
fix(river2): support River 2 family telemetry and offline states

### DIFF
--- a/custom_components/ecoflow_cloud/button.py
+++ b/custom_components/ecoflow_cloud/button.py
@@ -1,12 +1,9 @@
 import logging
 from typing import Any
 
-from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-from custom_components.ecoflow_cloud.entities import EcoFlowAbstractEntity
 
 from . import ECOFLOW_DOMAIN
 from .api import EcoflowApiClient
@@ -19,7 +16,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     client: EcoflowApiClient = hass.data[ECOFLOW_DOMAIN][entry.entry_id]
     for sn, device in client.devices.items():
         async_add_entities(device.buttons(client))
-        async_add_entities([ReconnectButtonEntity(client, device)])
 
 
 class EnabledButtonEntity(BaseButtonEntity):
@@ -32,14 +28,3 @@ class DisabledButtonEntity(BaseButtonEntity):
     async def async_press(self, **kwargs: Any) -> None:
         if self._command:
             self.send_set_message(0, self.command_dict(0))
-
-
-class ReconnectButtonEntity(ButtonEntity, EcoFlowAbstractEntity):
-    def __init__(self, client: EcoflowApiClient, device):
-        super().__init__(client, device, "Reconnect", "reconnect")
-        self._attr_device_class = ButtonDeviceClass.RESTART
-
-    async def async_press(self) -> None:
-        await self.hass.async_add_executor_job(self._client.stop)
-        await self._client.login()
-        await self.hass.async_add_executor_job(self._client.start)

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -4,10 +4,41 @@ DC_MODE_OPTIONS = {
     "Car Recharging": 2,
 }
 
+DC_MODE_LABELS = {code: label for label, code in DC_MODE_OPTIONS.items()}
+
 DC_ICONS = {
     "Auto": None,
     "MPPT": "mdi:solar-power",
     "DC": "mdi:current-dc",
+}
+
+# River 2 family FT307 MPPT/DC diagnostic bitmask. EcoFlow exposes these as
+# internal rail/input warnings; the integration keeps them diagnostic-only.
+FT307_FAULTS = {
+    1: {
+        "title": "DC input overvoltage",
+        "hint": "Input voltage is above the supported DC/solar range.",
+    },
+    2: {
+        "title": "DC input undervoltage",
+        "hint": "Input voltage is below the supported DC/solar range.",
+    },
+    4: {
+        "title": "DC input overcurrent",
+        "hint": "Input current is above the supported DC/solar range.",
+    },
+    8: {
+        "title": "DC input overtemperature",
+        "hint": "MPPT/DC input path reports overtemperature.",
+    },
+    16: {
+        "title": "DC input reverse polarity",
+        "hint": "Check DC input polarity before reconnecting the source.",
+    },
+    4096: {
+        "title": "No active DC input",
+        "hint": "Auxiliary idle/no-input warning; ignored when voltage/current/power are idle.",
+    },
 }
 
 SCREEN_TIMEOUT_OPTIONS = {
@@ -27,17 +58,10 @@ UNIT_TIMEOUT_OPTIONS = {
     "4 hr": 240,
     "6 hr": 360,
     "12 hr": 720,
-    "24 hr": 1440
+    "24 hr": 1440,
 }
 
-UNIT_TIMEOUT_OPTIONS_LIMITED = {
-    "Never": 0,
-    "30 min": 30,
-    "1 hr": 60,
-    "2 hr": 120,
-    "6 hr": 360,
-    "12 hr": 720
-}
+UNIT_TIMEOUT_OPTIONS_LIMITED = {"Never": 0, "30 min": 30, "1 hr": 60, "2 hr": 120, "6 hr": 360, "12 hr": 720}
 
 AC_TIMEOUT_OPTIONS = {
     "Never": 0,
@@ -79,41 +103,17 @@ DC_TIMEOUT_OPTIONS_LIMITED = {
     "24 hr": 1440,
 }
 
-DC_CHARGE_CURRENT_OPTIONS = {
-    "4A": 4000,
-    "6A": 6000,
-    "8A": 8000
-}
+DC_CHARGE_CURRENT_OPTIONS = {"4A": 4000, "6A": 6000, "8A": 8000}
 
-MAIN_MODE_OPTIONS = {
-    "Cool": 0,
-    "Heat": 1,
-    "Fan": 2
-}
+MAIN_MODE_OPTIONS = {"Cool": 0, "Heat": 1, "Fan": 2}
 
-FAN_MODE_OPTIONS = {
-    "Low": 0,
-    "Medium": 1,
-    "High": 2
-}
+FAN_MODE_OPTIONS = {"Low": 0, "Medium": 1, "High": 2}
 
-REMOTE_MODE_OPTIONS = {
-    "Startup": 1,
-    "Standby": 2,
-    "Shutdown": 3
-}
+REMOTE_MODE_OPTIONS = {"Startup": 1, "Standby": 2, "Shutdown": 3}
 
-POWER_SUB_MODE_OPTIONS = {
-    "Max": 0,
-    "Sleep": 1,
-    "Eco": 2,
-    "Manual": 3
-}
+POWER_SUB_MODE_OPTIONS = {"Max": 0, "Sleep": 1, "Eco": 2, "Manual": 3}
 
-POWER_SUPPLY_PRIORITY_OPTIONS = {
-    "Prioritize power supply": 0,
-    "Prioritize power storage": 1
-}
+POWER_SUPPLY_PRIORITY_OPTIONS = {"Prioritize power supply": 0, "Prioritize power storage": 1}
 CUSTOM_LOAD_POWER = "Custom Load Power"
 
 UTC_TIMEZONE = "Timezone"
@@ -331,10 +331,10 @@ SMART_METER_GRID_CONNECTION_POWER_FACTOR = "Grid connection power factor"
 SMART_METER_GRID_CONNECTION_STATE = "Grid connection state"
 
 # Stream AC
-STREAM_POWER_AC = "Power AC" # <0 import from home to battery / >0 export from battery to home
-STREAM_POWER_VOL = "Power Volts" # <0 import from home to battery / >0 export from battery to home
+STREAM_POWER_AC = "Power AC"  # <0 import from home to battery / >0 export from battery to home
+STREAM_POWER_VOL = "Power Volts"  # <0 import from home to battery / >0 export from battery to home
 STREAM_POWER_AMP = "Power In Amps"
-STREAM_POWER_AC_SYS = "Power AC SYS" # <0 import from home to battery / >0 export from battery to home
+STREAM_POWER_AC_SYS = "Power AC SYS"  # <0 import from home to battery / >0 export from battery to home
 STREAM_POWER_PV_1 = "Power PV 1"
 STREAM_POWER_PV_2 = "Power PV 2"
 STREAM_POWER_PV_3 = "Power PV 3"
@@ -348,15 +348,15 @@ STREAM_IN_VOL_PV_2 = "Power PV2 Volts"
 STREAM_IN_VOL_PV_3 = "Power PV3 Volts"
 STREAM_IN_VOL_PV_4 = "Power PV4 Volts"
 STREAM_POWER_PV_SUM = "Power PV Sum"
-STREAM_GET_SYS_LOAD = "Power Sys Load" # powGetSysLoad
-STREAM_GET_SYS_LOAD_FROM_BP = "Power Sys Load From Battery" # powGetSysLoadFromBp
-STREAM_GET_SYS_LOAD_FROM_GRID = "Power Sys Load From Grid" # powGetSysLoadFromGrid
-STREAM_GET_SYS_LOAD_FROM_PV = "Power Sys Load From PV" # powGetSysLoadFromPv
-STREAM_GET_SCHUKO1 = "Power SCHUKO1" # powGetSchuko1
-STREAM_GET_SCHUKO2 = "Power SCHUKO2" # powGetSchuko2
-STREAM_POWER_GRID = "Power Grid" # power from smart meter or shelly
-STREAM_POWER_BATTERY = "Power Battery" # <0 discharge battery / >0 charge batterie
-STREAM_POWER_BATTERY_SOC = "Power Battery SOC" # <0 discharge battery / >0 charge batterie
+STREAM_GET_SYS_LOAD = "Power Sys Load"  # powGetSysLoad
+STREAM_GET_SYS_LOAD_FROM_BP = "Power Sys Load From Battery"  # powGetSysLoadFromBp
+STREAM_GET_SYS_LOAD_FROM_GRID = "Power Sys Load From Grid"  # powGetSysLoadFromGrid
+STREAM_GET_SYS_LOAD_FROM_PV = "Power Sys Load From PV"  # powGetSysLoadFromPv
+STREAM_GET_SCHUKO1 = "Power SCHUKO1"  # powGetSchuko1
+STREAM_GET_SCHUKO2 = "Power SCHUKO2"  # powGetSchuko2
+STREAM_POWER_GRID = "Power Grid"  # power from smart meter or shelly
+STREAM_POWER_BATTERY = "Power Battery"  # <0 discharge battery / >0 charge batterie
+STREAM_POWER_BATTERY_SOC = "Power Battery SOC"  # <0 discharge battery / >0 charge batterie
 STREAM_BATTERY_LEVEL = "Battery Level"
 STREAM_DESIGN_CAPACITY = "Design Capacity"
 STREAM_FULL_CAPACITY = "Full Capacity"
@@ -384,33 +384,33 @@ SLAVE_N_ACCU_DISCHARGE_CAP = "Slave %i Cumulative Capacity Discharge (mAh)"
 SLAVE_N_ACCU_DISCHARGE_ENERGY = "Slave %i Cumulative Energy Discharge (Wh)"
 
 # Delta Pro Ultra
-PIO_PORT_CHARGING_POWER = "Power I/O Port Charging Power"                         
-PIO_PORT_N_POWER = "Power I/O Port %i Power"                                      
-PIO_PORT_N_CHARGE_REMAINING_TIME = "Power I/O Port %i Charge Remaining Time"      
+PIO_PORT_CHARGING_POWER = "Power I/O Port Charging Power"
+PIO_PORT_N_POWER = "Power I/O Port %i Power"
+PIO_PORT_N_CHARGE_REMAINING_TIME = "Power I/O Port %i Charge Remaining Time"
 PIO_PORT_N_DISCHARGE_REMAINING_TIME = "Power I/O Port %i Discharge Remaining Time"
-PIO_PORT_IN_POWER = "Power I/O Port Input Power"             
-PIO_PORT_IN_CURRENT = "Power I/O Port Input Current"         
-PIO_PORT_IN_VOLTAGE = "Power I/O Port Input Voltage"         
-PIO_PORT_OUT_POWER = "Power I/O Port Output Power"           
-PIO_PORT_OUT_CURRENT = "Power I/O Port Output Current"       
-PIO_PORT_OUT_VOLTAGE = "Power I/O Port Output Voltage"       
-PIO_PORT_OUT_FREQ = "Power I/O Port Output Frequency"        
-PIO_PORT_INPUT_TYPE = "Power I/O Port Input Type"            
-AC_N_OUT_POWER = "AC (%i) Out Power"                         
-AC_N_OUT_CURRENT = "AC (%i) Out Current"                     
-AC_N_OUT_VOLTAGE = "AC (%i) Out Voltage"                     
-AC_N_OUT_FREQ = "AC (%i) Out Frequency"                      
-WIRELESS_4G_ENABLED = "Wireless 4G Enabled"                  
-WIRELESS_4G_REGISTERED = "Wireless 4G Resgistered"           
-WIRELESS_4G_ERROR_CODE = "Wireless 4G Error Code"            
-WIRELESS_4G_DATA_MAX = "Wireless 4G Data Max"                
-WIRELESS_4G_DATA_REMAINING = "Wireless 4G Data Remaining"    
-WIRELESS_4G_SIM_ID = "Wireless 4G SIM ID"                    
-INTERNET_CONNECTION_TYPE = "Internet Connection Type"        
-BATTERY_COUNT = "Battery Count"                              
+PIO_PORT_IN_POWER = "Power I/O Port Input Power"
+PIO_PORT_IN_CURRENT = "Power I/O Port Input Current"
+PIO_PORT_IN_VOLTAGE = "Power I/O Port Input Voltage"
+PIO_PORT_OUT_POWER = "Power I/O Port Output Power"
+PIO_PORT_OUT_CURRENT = "Power I/O Port Output Current"
+PIO_PORT_OUT_VOLTAGE = "Power I/O Port Output Voltage"
+PIO_PORT_OUT_FREQ = "Power I/O Port Output Frequency"
+PIO_PORT_INPUT_TYPE = "Power I/O Port Input Type"
+AC_N_OUT_POWER = "AC (%i) Out Power"
+AC_N_OUT_CURRENT = "AC (%i) Out Current"
+AC_N_OUT_VOLTAGE = "AC (%i) Out Voltage"
+AC_N_OUT_FREQ = "AC (%i) Out Frequency"
+WIRELESS_4G_ENABLED = "Wireless 4G Enabled"
+WIRELESS_4G_REGISTERED = "Wireless 4G Resgistered"
+WIRELESS_4G_ERROR_CODE = "Wireless 4G Error Code"
+WIRELESS_4G_DATA_MAX = "Wireless 4G Data Max"
+WIRELESS_4G_DATA_REMAINING = "Wireless 4G Data Remaining"
+WIRELESS_4G_SIM_ID = "Wireless 4G SIM ID"
+INTERNET_CONNECTION_TYPE = "Internet Connection Type"
+BATTERY_COUNT = "Battery Count"
 BATTERY_AUTO_HEATING_ENABLED = "Battery Auto-Heating Enabled"
-ERROR_CODE = "Error Code"                      
-AC_IN_CURRENT = "AC In Current"                
+ERROR_CODE = "Error Code"
+AC_IN_CURRENT = "AC In Current"
 
 # Smart Home Panel
 
@@ -441,7 +441,7 @@ BATTERY_N_OUT_POWER = "Battery %i Output Power"
 BATTERY_N_CURRENT = "Battery %i Current"
 CIRCUIT_N_CURRENT = "Circuit %i Current"
 
-#Smart Home Panel 2
+# Smart Home Panel 2
 
 STORM_GUARD = "Storm Guard"
 IN_STORM_MODE = "In Storm Mode"
@@ -452,12 +452,7 @@ BATTERY_N_FORCE_CHARGE = "Battery %i Force Charge"
 RELAY_N_OPERATION_COUNT = "Relay %i Operation Count"
 SMART_BACKUP_MODE = "Operating Mode"
 
-SMART_BACKUP_MODE_OPTIONS = {
-    "None": 0,
-    "TOU" : 1,
-    "Self-powered" : 2,
-    "Scheduled tasks": 3
-}
+SMART_BACKUP_MODE_OPTIONS = {"None": 0, "TOU": 1, "Self-powered": 2, "Scheduled tasks": 3}
 
 # Alternator 800W
 ALTERNATOR_OPERATION_MODE_OPTIONS = {

--- a/custom_components/ecoflow_cloud/devices/data_holder.py
+++ b/custom_components/ecoflow_cloud/devices/data_holder.py
@@ -36,8 +36,11 @@ class DataStatusCallback(Protocol):
 
 
 class _NoOpStatusCallback:
-    def on_explicit_status(self, online: bool) -> None: pass
-    def on_data_received(self) -> None: pass
+    def on_explicit_status(self, online: bool) -> None:
+        pass
+
+    def on_data_received(self) -> None:
+        pass
 
 
 class EcoflowDataHolder:
@@ -66,10 +69,12 @@ class EcoflowDataHolder:
 
         self.set_status = BoundFifoList[dict[str, Any]]()
         self.set_status_time = dt.utcnow().replace(year=2000, month=1, day=1, hour=0, minute=0, second=0)
+        self.status_change_time = dt.utcnow().replace(year=2000, month=1, day=1, hour=0, minute=0, second=0)
 
     def last_received_time(self):
         return max(
             self.set_status_time,
+            self.status_change_time,
             self.set_params_time,
             # 1. get_reply can receive '"message": "The device is not online"'
             # 2. if device is online - get_reply message will update params, so param_time will be updated as well
@@ -120,6 +125,7 @@ class EcoflowDataHolder:
     def __accept_prepared_data(self, data: PreparedData, raw_data_acceptor: Callable[[dict[str, Any]], None]):
         if data.online is not None:
             self._status_callback.on_explicit_status(data.online)
+            self.status_change_time = dt.utcnow()
 
         if data.params is not None:
             self.__update_params(data.params)

--- a/custom_components/ecoflow_cloud/devices/data_holder.py
+++ b/custom_components/ecoflow_cloud/devices/data_holder.py
@@ -108,6 +108,9 @@ class EcoflowDataHolder:
         self.__accept_prepared_data(data, self.set_status.append)
         self.set_status_time = dt.utcnow()
 
+    def mark_status_changed(self) -> None:
+        self.status_change_time = dt.utcnow()
+
     def add_data(self, data: PreparedData):
         if data.params is not None and self.module_sn is not None:
             if "moduleSn" not in data.params:

--- a/custom_components/ecoflow_cloud/devices/internal/river2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2.py
@@ -16,9 +16,10 @@ from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
+    DcModeStateSensorEntity,
+    Ft307FaultCodeSensorEntity,
     InMilliampSensorEntity,
     InMilliVoltSensorEntity,
-    InVoltSensorEntity,
     InWattsSensorEntity,
     LevelSensorEntity,
     MilliVoltSensorEntity,
@@ -52,8 +53,10 @@ class River2(BaseInternalDevice):
             ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER).with_energy(),
-            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
+            # River 2 reports live PV telemetry under mppt.*; inv.dcIn* stays at 0
+            # even while solar input power is non-zero.
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT, entity_key="inv.dcInAmp"),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE, entity_key="inv.dcInVol"),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER).with_energy(),
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
@@ -63,6 +66,15 @@ class River2(BaseInternalDevice):
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
+            # River 2 family exposes only the user-facing 12V/car output toggle.
+            # These mppt.* fields are still useful diagnostics for understanding
+            # which DC path is active and whether the internal 24V rail is alive,
+            # but they are not a confirmed switchable 24V output like Delta Pro 3.
+            # Keep the configured-key unique ID so the runtime sensor does not respawn under a new entity ID.
+            DcModeStateSensorEntity(
+                client, self, "mppt.chgType", "DC Mode", diagnostic=True, entity_key="mppt.cfgChgType"
+            ),
+            Ft307FaultCodeSensorEntity(client, self, "mppt.faultCode", "MPPT Fault", diagnostic=True),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
             RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),

--- a/custom_components/ecoflow_cloud/devices/internal/river2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_max.py
@@ -16,9 +16,10 @@ from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
+    DcModeStateSensorEntity,
+    Ft307FaultCodeSensorEntity,
     InMilliampSensorEntity,
     InMilliVoltSensorEntity,
-    InVoltSensorEntity,
     InWattsSensorEntity,
     LevelSensorEntity,
     MilliVoltSensorEntity,
@@ -52,8 +53,10 @@ class River2Max(BaseInternalDevice):
             ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER).with_energy(),
-            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
+            # River 2 reports live PV telemetry under mppt.*; inv.dcIn* stays at 0
+            # even while solar input power is non-zero.
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT, entity_key="inv.dcInAmp"),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE, entity_key="inv.dcInVol"),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER).with_energy(),
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
@@ -63,6 +66,15 @@ class River2Max(BaseInternalDevice):
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
+            # River 2 family exposes only the user-facing 12V/car output toggle.
+            # These mppt.* fields are still useful diagnostics for understanding
+            # which DC path is active and whether the internal 24V rail is alive,
+            # but they are not a confirmed switchable 24V output like Delta Pro 3.
+            # Keep the configured-key unique ID so the runtime sensor does not respawn under a new entity ID.
+            DcModeStateSensorEntity(
+                client, self, "mppt.chgType", "DC Mode", diagnostic=True, entity_key="mppt.cfgChgType"
+            ),
+            Ft307FaultCodeSensorEntity(client, self, "mppt.faultCode", "MPPT Fault", diagnostic=True),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
             RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),

--- a/custom_components/ecoflow_cloud/devices/internal/river2_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_pro.py
@@ -16,6 +16,9 @@ from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
+    DcModeStateSensorEntity,
+    Ft307FaultCodeSensorEntity,
+    InMilliampSensorEntity,
     InMilliVoltSensorEntity,
     InWattsSensorEntity,
     LevelSensorEntity,
@@ -54,10 +57,21 @@ class River2Pro(BaseInternalDevice):
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
             InWattsSensorEntity(client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER),
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT, entity_key="inv.dcInAmp"),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE, entity_key="inv.dcInVol"),
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
+            # River 2 family exposes only the user-facing 12V/car output toggle.
+            # These mppt.* fields are still useful diagnostics for understanding
+            # which DC path is active and whether the internal 24V rail is alive,
+            # but they are not a confirmed switchable 24V output like Delta Pro 3.
+            # Keep the configured-key unique ID so the runtime sensor does not respawn under a new entity ID.
+            DcModeStateSensorEntity(
+                client, self, "mppt.chgType", "DC Mode", diagnostic=True, entity_key="mppt.cfgChgType"
+            ),
+            Ft307FaultCodeSensorEntity(client, self, "mppt.faultCode", "MPPT Fault", diagnostic=True),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
             RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),

--- a/custom_components/ecoflow_cloud/devices/status_coordinator.py
+++ b/custom_components/ecoflow_cloud/devices/status_coordinator.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from ..api import EcoflowApiClient
+from .data_coordinator import EcoflowBroadcastDataHolder
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,9 +45,7 @@ class DeviceStatusCoordinator(DataUpdateCoordinator[None]):
 
     def _actualize_interval(self) -> None:
         interval = min(
-            (d.device_data.options.assume_offline_sec
-             for c in self._clients.values()
-             for d in c.devices.values()),
+            (d.device_data.options.assume_offline_sec for c in self._clients.values() for d in c.devices.values()),
             default=DEFAULT_STATUS_POLL_INTERVAL_SEC,
         )
         self.update_interval = datetime.timedelta(seconds=interval)
@@ -80,9 +79,7 @@ class DeviceStatusCoordinator(DataUpdateCoordinator[None]):
 
         # Only poll if at least one device needs status clarification
         needs_poll = any(
-            device.status_tracker.wants_status_poll
-            for devices in all_devices.values()
-            for device in devices
+            device.status_tracker.wants_status_poll for devices in all_devices.values() for device in devices
         )
         if not needs_poll:
             _LOGGER.debug("No devices need status poll — skipping")
@@ -98,4 +95,7 @@ class DeviceStatusCoordinator(DataUpdateCoordinator[None]):
 
             for api_device in api_devices:
                 for device in all_devices.get(api_device.sn, []):
-                    device.status_tracker.on_explicit_status(api_device.status == 1)
+                    online = api_device.status == 1
+                    device.status_tracker.on_explicit_status(online)
+                    device.data.mark_status_changed()
+                    device.coordinator.async_set_updated_data(EcoflowBroadcastDataHolder(device.data, online))

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -94,8 +94,9 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         enabled: bool = True,
         auto_enable: bool = False,
         diagnostic: Optional[bool] = None,
+        entity_key: str | None = None,
     ):
-        super().__init__(client, device, title, mqtt_key)
+        super().__init__(client, device, title, entity_key or mqtt_key)
 
         self.__mqtt_key = mqtt_key
         self._mqtt_key_adopted = self._adopt_json_key(mqtt_key)
@@ -269,8 +270,9 @@ class BaseSensorEntity(SensorEntity, EcoFlowDictEntity):  # type: ignore[misc]
         enabled: bool = True,
         auto_enable: bool = False,
         diagnostic: Optional[bool] = None,
+        entity_key: str | None = None,
     ):
-        super().__init__(client, device, mqtt_key, title, enabled, auto_enable, diagnostic)
+        super().__init__(client, device, mqtt_key, title, enabled, auto_enable, diagnostic, entity_key)
         if self._attr_default_value is not None:
             self._attr_native_value = self._attr_default_value
 

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -175,6 +175,7 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         # update value
         values = self._mqtt_key_expr.find(data)
         if len(values) == 1 or (len(values) > 1 and self._multiple_value_sum):
+            was_available = bool(self._attr_available)
             self._attr_available = True
             if self._auto_enable:
                 self._attr_entity_registry_enabled_default = True
@@ -184,7 +185,7 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
             if len(values) > 1 and self._multiple_value_sum:
                 for v in values[1:]:
                     total += v.value
-            if self._update_value(total):
+            if self._update_value(total) or not was_available:
                 self.schedule_update_ha_state()
 
     @property

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -124,6 +124,10 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
             return key
 
     @property
+    def available(self) -> bool:
+        return bool(self._attr_available) and not self._device.status_tracker.is_offline
+
+    @property
     def mqtt_key(self):
         return self.__mqtt_key
 
@@ -141,13 +145,19 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         # self.async_on_remove(d.dispose)
 
     def _handle_coordinator_update(self) -> None:
+        if self._device.status_tracker.is_offline:
+            self._mark_unavailable()
+            return
+
         if self.coordinator.data.changed:
             self._updated(self.coordinator.data.data_holder.params)
-        elif self._device.status_tracker.is_offline:  # Device is offline
-            # Reset sensors that should reset to default values
-            if isinstance(self, BaseSensorEntity) and self._attr_default_value is not None:
-                self._mqtt_key_expr.update(self.coordinator.data.data_holder.params, self._attr_default_value)
-                self._updated(self.coordinator.data.data_holder.params)
+
+    def _mark_unavailable(self) -> None:
+        if not self._attr_available:
+            return
+
+        self._attr_available = False
+        self.schedule_update_ha_state()
 
     def _updated(self, data: dict[str, Any]):
         # update attributes

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -45,6 +45,7 @@ from . import (
     ECOFLOW_DOMAIN,
 )
 from .api import EcoflowApiClient
+from .devices.data_coordinator import EcoflowBroadcastDataHolder
 from .devices import BaseDevice, const
 from .entities import (
     BaseSensorEntity,
@@ -688,6 +689,8 @@ class StatusSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):  # type: igno
                 self._attr_native_value = status.label
                 self._actualize_attributes()
                 self.schedule_update_ha_state()
+            if status.online is not True:
+                self.coordinator.async_set_updated_data(EcoflowBroadcastDataHolder(self._device.data, False))
 
     def _format_age(self, timestamp: datetime | None) -> str | None:
         if timestamp is None:

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -126,6 +126,152 @@ class MiscSensorEntity(BaseSensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
 
+class DcModeStateSensorEntity(MiscSensorEntity):
+    """Expose the live DC input mode without duplicating the config select."""
+
+    _attr_icon = "mdi:tune-variant"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw_code: int | None = None
+
+    def _runtime_mode(self) -> tuple[int | None, str | None]:
+        params = self._device.data.params
+        runtime_code = params.get("mppt.chgType")
+        if runtime_code is None:
+            return None, None
+        runtime_code = int(runtime_code)
+        if runtime_code == 255:
+            return runtime_code, "No active DC input"
+        return runtime_code, const.DC_MODE_LABELS.get(runtime_code, f"Unknown ({runtime_code})")
+
+    @property
+    def icon(self) -> str | None:
+        if self._raw_code == 255:
+            return "mdi:power-plug-off-outline"
+        if self._raw_code == const.DC_MODE_OPTIONS["Solar Recharging"]:
+            return "mdi:solar-power"
+        if self._raw_code == const.DC_MODE_OPTIONS["Car Recharging"]:
+            return "mdi:car-electric"
+        if self._raw_code == const.DC_MODE_OPTIONS["Auto"]:
+            return "mdi:tune-variant"
+        return "mdi:help-circle-outline"
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs["raw_code"] = self._raw_code
+        configured_code = self._device.data.params.get("mppt.cfgChgType")
+        if configured_code is not None:
+            configured_code = int(configured_code)
+        attrs["configured_code"] = configured_code
+        attrs["configured_mode"] = (
+            const.DC_MODE_LABELS.get(configured_code, f"Unknown ({configured_code})")
+            if configured_code is not None
+            else None
+        )
+        runtime_code, runtime_mode = self._runtime_mode()
+        attrs["runtime_code"] = runtime_code
+        attrs["runtime_mode"] = runtime_mode
+        return attrs
+
+    def _update_value(self, val: Any) -> bool:
+        runtime_code = int(val)
+        runtime_mode = self._runtime_mode()[1]
+        self._raw_code = runtime_code
+        label = runtime_mode or f"Unknown ({runtime_code})"
+        return super()._update_value(label)
+
+    def _updated(self, data: dict[str, Any]):
+        params = self._device.data.params
+        runtime_code = params.get("mppt.chgType")
+        if runtime_code is None:
+            return
+
+        self._attr_available = True
+        if self._update_value(runtime_code):
+            self.schedule_update_ha_state()
+
+
+class Ft307FaultCodeSensorEntity(MiscSensorEntity):
+    """Decode the FT307 MPPT/DC fault bitmask into readable diagnostics."""
+
+    _attr_icon = "mdi:check-circle-outline"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw_code: int | None = None
+        self._active_faults: list[dict[str, Any]] = []
+        self._unknown_bits: int = 0
+        self._suppressed_faults: list[dict[str, Any]] = []
+
+    def _dc_input_is_effectively_idle(self) -> bool:
+        params = self._device.data.params
+        in_watts = int(params.get("mppt.inWatts", 0) or 0)
+        in_vol = int(params.get("mppt.inVol", 0) or 0)
+        in_amp = int(params.get("mppt.inAmp", 0) or 0)
+        return in_watts == 0 and in_vol < 5000 and in_amp < 100
+
+    @property
+    def icon(self) -> str | None:
+        if self._active_faults:
+            return "mdi:alert-octagon-outline"
+        if self._suppressed_faults:
+            return "mdi:minus-circle-outline"
+        return self._attr_icon
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs["raw_code"] = self._raw_code
+        attrs["active_faults"] = self._active_faults
+        if self._suppressed_faults:
+            attrs["suppressed_faults"] = self._suppressed_faults
+        if self._unknown_bits:
+            attrs["unknown_bits"] = self._unknown_bits
+        return attrs
+
+    def _update_value(self, val: Any) -> bool:
+        code = int(val)
+        self._raw_code = code
+        self._active_faults = []
+        self._unknown_bits = 0
+        self._suppressed_faults = []
+
+        if code == 0:
+            return super()._update_value("No fault")
+
+        known_mask = 0
+        for bit, meta in sorted(const.FT307_FAULTS.items()):
+            known_mask |= bit
+            if not (code & bit):
+                continue
+            fault = {"bit": bit, "title": meta["title"], "hint": meta["hint"]}
+            if bit == 4096 and self._dc_input_is_effectively_idle():
+                self._suppressed_faults.append(fault)
+                continue
+            self._active_faults.append(fault)
+
+        self._unknown_bits = code & ~known_mask
+        if self._unknown_bits:
+            self._active_faults.append(
+                {
+                    "bit": self._unknown_bits,
+                    "title": f"Unknown fault bits (0x{self._unknown_bits:X})",
+                    "hint": None,
+                }
+            )
+
+        if not self._active_faults and self._suppressed_faults:
+            return super()._update_value("No active DC fault")
+        if len(self._active_faults) == 1:
+            label = self._active_faults[0]["title"]
+        else:
+            label = "; ".join(fault["title"] for fault in self._active_faults)
+
+        return super()._update_value(label)
+
+
 class LevelSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -412,9 +558,11 @@ class InAmpSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:transmission-tower-import"
     _attr_suggested_display_precision = 2
 
+
 class InRawAmpSolarSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:solar-power"
     _attr_suggested_display_precision = 2
+
 
 class OutMilliampSensorEntity(MilliampSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"
@@ -527,9 +675,7 @@ class StatusSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):  # type: igno
         # Scheduled periodic refresh regardless of status
         if self._scheduled_refresh_sec is not None:
             if (dt.utcnow() - self._last_scheduled).total_seconds() > self._scheduled_refresh_sec:
-                self.hass.async_create_background_task(
-                    self._client.quota_all(self._device.device_info.sn), "get quota"
-                )
+                self.hass.async_create_background_task(self._client.quota_all(self._device.device_info.sn), "get quota")
                 self._last_scheduled = dt.utcnow()
                 self._poll_count += 1
                 self._attrs[ATTR_QUOTA_REQUESTS] = self._poll_count
@@ -589,7 +735,7 @@ class IntegralEnergySensorEntity(IntegrationSensor):
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_entity_registry_visible_default = False
 
     def __init__(self, base: WattsSensorEntity, enabled_default: bool = True):
@@ -723,4 +869,4 @@ class WattsDifferenceSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):
         if input_val is None or output_val is None or input_val is STATE_UNKNOWN or output_val is STATE_UNKNOWN:
             self._difference = None
             return
-        self._difference = float(output_val) - float(input_val)        
+        self._difference = float(output_val) - float(input_val)

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -135,6 +135,7 @@ class DcModeStateSensorEntity(MiscSensorEntity):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._raw_code: int | None = None
+        self._configured_code: int | None = None
 
     def _runtime_mode(self) -> tuple[int | None, str | None]:
         params = self._device.data.params
@@ -189,8 +190,16 @@ class DcModeStateSensorEntity(MiscSensorEntity):
         if runtime_code is None:
             return
 
+        configured_code = params.get("mppt.cfgChgType")
+        if configured_code is not None:
+            configured_code = int(configured_code)
+
+        was_available = bool(self._attr_available)
         self._attr_available = True
-        if self._update_value(runtime_code):
+        updated = self._update_value(runtime_code)
+        configured_changed = configured_code != self._configured_code
+        self._configured_code = configured_code
+        if updated or configured_changed or not was_available:
             self.schedule_update_ha_state()
 
 

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -127,6 +127,152 @@ class MiscSensorEntity(BaseSensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
 
+class DcModeStateSensorEntity(MiscSensorEntity):
+    """Expose the live DC input mode without duplicating the config select."""
+
+    _attr_icon = "mdi:tune-variant"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw_code: int | None = None
+
+    def _runtime_mode(self) -> tuple[int | None, str | None]:
+        params = self._device.data.params
+        runtime_code = params.get("mppt.chgType")
+        if runtime_code is None:
+            return None, None
+        runtime_code = int(runtime_code)
+        if runtime_code == 255:
+            return runtime_code, "No active DC input"
+        return runtime_code, const.DC_MODE_LABELS.get(runtime_code, f"Unknown ({runtime_code})")
+
+    @property
+    def icon(self) -> str | None:
+        if self._raw_code == 255:
+            return "mdi:power-plug-off-outline"
+        if self._raw_code == const.DC_MODE_OPTIONS["Solar Recharging"]:
+            return "mdi:solar-power"
+        if self._raw_code == const.DC_MODE_OPTIONS["Car Recharging"]:
+            return "mdi:car-electric"
+        if self._raw_code == const.DC_MODE_OPTIONS["Auto"]:
+            return "mdi:tune-variant"
+        return "mdi:help-circle-outline"
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs["raw_code"] = self._raw_code
+        configured_code = self._device.data.params.get("mppt.cfgChgType")
+        if configured_code is not None:
+            configured_code = int(configured_code)
+        attrs["configured_code"] = configured_code
+        attrs["configured_mode"] = (
+            const.DC_MODE_LABELS.get(configured_code, f"Unknown ({configured_code})")
+            if configured_code is not None
+            else None
+        )
+        runtime_code, runtime_mode = self._runtime_mode()
+        attrs["runtime_code"] = runtime_code
+        attrs["runtime_mode"] = runtime_mode
+        return attrs
+
+    def _update_value(self, val: Any) -> bool:
+        runtime_code = int(val)
+        runtime_mode = self._runtime_mode()[1]
+        self._raw_code = runtime_code
+        label = runtime_mode or f"Unknown ({runtime_code})"
+        return super()._update_value(label)
+
+    def _updated(self, data: dict[str, Any]):
+        params = self._device.data.params
+        runtime_code = params.get("mppt.chgType")
+        if runtime_code is None:
+            return
+
+        self._attr_available = True
+        if self._update_value(runtime_code):
+            self.schedule_update_ha_state()
+
+
+class Ft307FaultCodeSensorEntity(MiscSensorEntity):
+    """Decode the FT307 MPPT/DC fault bitmask into readable diagnostics."""
+
+    _attr_icon = "mdi:check-circle-outline"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw_code: int | None = None
+        self._active_faults: list[dict[str, Any]] = []
+        self._unknown_bits: int = 0
+        self._suppressed_faults: list[dict[str, Any]] = []
+
+    def _dc_input_is_effectively_idle(self) -> bool:
+        params = self._device.data.params
+        in_watts = int(params.get("mppt.inWatts", 0) or 0)
+        in_vol = int(params.get("mppt.inVol", 0) or 0)
+        in_amp = int(params.get("mppt.inAmp", 0) or 0)
+        return in_watts == 0 and in_vol < 5000 and in_amp < 100
+
+    @property
+    def icon(self) -> str | None:
+        if self._active_faults:
+            return "mdi:alert-octagon-outline"
+        if self._suppressed_faults:
+            return "mdi:minus-circle-outline"
+        return self._attr_icon
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs["raw_code"] = self._raw_code
+        attrs["active_faults"] = self._active_faults
+        if self._suppressed_faults:
+            attrs["suppressed_faults"] = self._suppressed_faults
+        if self._unknown_bits:
+            attrs["unknown_bits"] = self._unknown_bits
+        return attrs
+
+    def _update_value(self, val: Any) -> bool:
+        code = int(val)
+        self._raw_code = code
+        self._active_faults = []
+        self._unknown_bits = 0
+        self._suppressed_faults = []
+
+        if code == 0:
+            return super()._update_value("No fault")
+
+        known_mask = 0
+        for bit, meta in sorted(const.FT307_FAULTS.items()):
+            known_mask |= bit
+            if not (code & bit):
+                continue
+            fault = {"bit": bit, "title": meta["title"], "hint": meta["hint"]}
+            if bit == 4096 and self._dc_input_is_effectively_idle():
+                self._suppressed_faults.append(fault)
+                continue
+            self._active_faults.append(fault)
+
+        self._unknown_bits = code & ~known_mask
+        if self._unknown_bits:
+            self._active_faults.append(
+                {
+                    "bit": self._unknown_bits,
+                    "title": f"Unknown fault bits (0x{self._unknown_bits:X})",
+                    "hint": None,
+                }
+            )
+
+        if not self._active_faults and self._suppressed_faults:
+            return super()._update_value("No active DC fault")
+        if len(self._active_faults) == 1:
+            label = self._active_faults[0]["title"]
+        else:
+            label = "; ".join(fault["title"] for fault in self._active_faults)
+
+        return super()._update_value(label)
+
+
 class LevelSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -413,9 +559,11 @@ class InAmpSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:transmission-tower-import"
     _attr_suggested_display_precision = 2
 
+
 class InRawAmpSolarSensorEntity(AmpSensorEntity):
     _attr_icon = "mdi:solar-power"
     _attr_suggested_display_precision = 2
+
 
 class OutMilliampSensorEntity(MilliampSensorEntity):
     _attr_icon = "mdi:transmission-tower-export"
@@ -532,9 +680,7 @@ class StatusSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):  # type: igno
         # Scheduled periodic refresh regardless of status
         if self._scheduled_refresh_sec is not None:
             if (dt.utcnow() - self._last_scheduled).total_seconds() > self._scheduled_refresh_sec:
-                self.hass.async_create_background_task(
-                    self._client.quota_all(self._device.device_info.sn), "get quota"
-                )
+                self.hass.async_create_background_task(self._client.quota_all(self._device.device_info.sn), "get quota")
                 self._last_scheduled = dt.utcnow()
                 self._poll_count += 1
                 self._attrs[ATTR_QUOTA_REQUESTS] = self._poll_count
@@ -617,7 +763,7 @@ class IntegralEnergySensorEntity(IntegrationSensor):
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_entity_registry_visible_default = False
 
     def __init__(self, base: WattsSensorEntity, enabled_default: bool = True):
@@ -751,4 +897,4 @@ class WattsDifferenceSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):
         if input_val is None or output_val is None or input_val is STATE_UNKNOWN or output_val is STATE_UNKNOWN:
             self._difference = None
             return
-        self._difference = float(output_val) - float(input_val)        
+        self._difference = float(output_val) - float(input_val)

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -136,6 +136,7 @@ class DcModeStateSensorEntity(MiscSensorEntity):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._raw_code: int | None = None
+        self._configured_code: int | None = None
 
     def _runtime_mode(self) -> tuple[int | None, str | None]:
         params = self._device.data.params
@@ -190,8 +191,16 @@ class DcModeStateSensorEntity(MiscSensorEntity):
         if runtime_code is None:
             return
 
+        configured_code = params.get("mppt.cfgChgType")
+        if configured_code is not None:
+            configured_code = int(configured_code)
+
+        was_available = bool(self._attr_available)
         self._attr_available = True
-        if self._update_value(runtime_code):
+        updated = self._update_value(runtime_code)
+        configured_changed = configured_code != self._configured_code
+        self._configured_code = configured_code
+        if updated or configured_changed or not was_available:
             self.schedule_update_ha_state()
 
 

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -46,6 +46,7 @@ from . import (
     ECOFLOW_DOMAIN,
 )
 from .api import EcoflowApiClient
+from .devices.data_coordinator import EcoflowBroadcastDataHolder
 from .devices import BaseDevice, const
 from .entities import (
     BaseSensorEntity,
@@ -693,6 +694,8 @@ class StatusSensorEntity(SensorEntity, EcoFlowAbstractDataEntity):  # type: igno
                 self._attr_native_value = status.label
                 self._actualize_attributes()
                 self.schedule_update_ha_state()
+            if status.online is not True:
+                self.coordinator.async_set_updated_data(EcoflowBroadcastDataHolder(self._device.data, False))
 
     def _schedule_mqtt_reconnect(self) -> bool:
         reconnect_count = self._client.schedule_mqtt_reconnect()

--- a/docs/devices/RIVER_2.md
+++ b/docs/devices/RIVER_2.md
@@ -10,8 +10,8 @@
 - Battery Charging State (`bms_emsStatus.chgState`)
 - Total In Power (`pd.wattsInSum`) (energy:  _[Device Name]_ Total In  Energy)
 - Total Out Power (`pd.wattsOutSum`) (energy:  _[Device Name]_ Total Out  Energy)
-- Solar In Current (`inv.dcInAmp`)
-- Solar In Voltage (`inv.dcInVol`)
+- Solar In Current (`mppt.inAmp`)
+- Solar In Voltage (`mppt.inVol`)
 - AC In Power (`inv.inputWatts`) (energy:  _[Device Name]_ AC In  Energy)
 - AC Out Power (`inv.outputWatts`) (energy:  _[Device Name]_ AC Out  Energy)
 - AC In Volts (`inv.acInVol`)
@@ -21,6 +21,8 @@
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typec1Watts`)
 - USB Out Power (`pd.usb1Watts`)
+- DC Mode (`mppt.chgType`)   _(diagnostic; state shows the live runtime mode, attributes still include configured/runtime raw values, and runtime `255` is shown as `No active DC input`)_
+- MPPT Fault (`mppt.faultCode`)   _(diagnostic; decoded title with raw bitmask in attributes, with idle/no-input auxiliary warnings suppressed into attributes instead of shown as active faults)_
 - Charge Remaining Time (`bms_emsStatus.chgRemainTime`)
 - Discharge Remaining Time (`bms_emsStatus.dsgRemainTime`)
 - Remaining Time (`pd.remainTime`)
@@ -55,3 +57,5 @@
 - AC Timeout (`mppt.acStandbyMins` -> `{"moduleType": 5, "operateType": "acStandby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
 
+
+_Note: River 2 family exposes a user-facing DC (12V/car) output via `pd.carState`, but there is no confirmed dedicated 24V output control path like Delta Pro 3 `cfgDc24vOutOpen`._

--- a/docs/devices/RIVER_2_MAX.md
+++ b/docs/devices/RIVER_2_MAX.md
@@ -10,8 +10,8 @@
 - Battery Charging State (`bms_emsStatus.chgState`)
 - Total In Power (`pd.wattsInSum`) (energy:  _[Device Name]_ Total In  Energy)
 - Total Out Power (`pd.wattsOutSum`) (energy:  _[Device Name]_ Total Out  Energy)
-- Solar In Current (`inv.dcInAmp`)
-- Solar In Voltage (`inv.dcInVol`)
+- Solar In Current (`mppt.inAmp`)
+- Solar In Voltage (`mppt.inVol`)
 - AC In Power (`inv.inputWatts`) (energy:  _[Device Name]_ AC In  Energy)
 - AC Out Power (`inv.outputWatts`) (energy:  _[Device Name]_ AC Out  Energy)
 - AC In Volts (`inv.acInVol`)
@@ -21,6 +21,8 @@
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typec1Watts`)
 - USB Out Power (`pd.usb1Watts`)
+- DC Mode (`mppt.chgType`)   _(diagnostic; state shows the live runtime mode, attributes still include configured/runtime raw values, and runtime `255` is shown as `No active DC input`)_
+- MPPT Fault (`mppt.faultCode`)   _(diagnostic; decoded title with raw bitmask in attributes, with idle/no-input auxiliary warnings suppressed into attributes instead of shown as active faults)_
 - Charge Remaining Time (`bms_emsStatus.chgRemainTime`)
 - Discharge Remaining Time (`bms_emsStatus.dsgRemainTime`)
 - Remaining Time (`pd.remainTime`)
@@ -55,3 +57,5 @@
 - AC Timeout (`mppt.acStandbyMins` -> `{"moduleType": 5, "operateType": "acStandby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
 
+
+_Note: River 2 family exposes a user-facing DC (12V/car) output via `pd.carState`, but there is no confirmed dedicated 24V output control path like Delta Pro 3 `cfgDc24vOutOpen`._

--- a/docs/devices/RIVER_2_PRO.md
+++ b/docs/devices/RIVER_2_PRO.md
@@ -15,10 +15,14 @@
 - AC In Volts (`inv.acInVol`)
 - AC Out Volts (`inv.invOutVol`)
 - Type-C In Power (`pd.typecChaWatts`)
+- Solar In Current (`mppt.inAmp`)
+- Solar In Voltage (`mppt.inVol`)
 - Solar In Power (`mppt.inWatts`) (energy:  _[Device Name]_ Solar In  Energy)
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typec1Watts`)
 - USB Out Power (`pd.usb1Watts`)
+- DC Mode (`mppt.chgType`)   _(diagnostic; state shows the live runtime mode, attributes still include configured/runtime raw values, and runtime `255` is shown as `No active DC input`)_
+- MPPT Fault (`mppt.faultCode`)   _(diagnostic; decoded title with raw bitmask in attributes, with idle/no-input auxiliary warnings suppressed into attributes instead of shown as active faults)_
 - Charge Remaining Time (`bms_emsStatus.chgRemainTime`)
 - Discharge Remaining Time (`bms_emsStatus.dsgRemainTime`)
 - Remaining Time (`pd.remainTime`)
@@ -52,3 +56,5 @@
 - AC Timeout (`mppt.acStandbyMins` -> `{"moduleType": 5, "operateType": "acStandby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
 
+
+_Note: River 2 family exposes a user-facing DC (12V/car) output via `pd.carState`, but there is no confirmed dedicated 24V output control path like Delta Pro 3 `cfgDc24vOutOpen`._


### PR DESCRIPTION
## Summary

This PR narrows the remaining River 2 work to device-family telemetry and
offline-state handling.

It is now rebased on current `main`, after the MQTT reconnect/status-id fixes
from #787 and #789. Those fixes are intentionally not duplicated here. This PR
does not replace the MQTT client; it keeps the upstream MQTT path from `main`.

## What changes

- Read River 2 and River 2 Max solar current/voltage from live `mppt.*`
  telemetry while preserving the existing `inv.dcIn*` entity IDs.
- Add matching River 2 Pro solar current/voltage support.
- Expose River 2 family DC mode and MPPT fault diagnostics.
- Remove the generic per-device `Reconnect` button while keeping
  device-specific buttons.
- Mark integration-derived energy sensors as `total` for Home Assistant Energy
  compatibility.
- Make data entities unavailable on explicit offline status instead of
  reporting stale/default `0` values.
- Propagate `/device/list` status-poll results into per-device coordinators so
  explicit offline status updates HA availability.

## Notes for review

- MQTT reconnect handling is already in #787.
- Scheduled status entity ID stability is already in #789.
- `ASSUME_OFFLINE` remains a soft "silent for now" state; only explicit
  `OFFLINE` hides telemetry.
- River 2 solar entity IDs stay stable: `entity_key` preserves the old
  `inv.dcIn*` unique IDs while values are sourced from `mppt.*`.

## Validation

- `python3 -m ruff check custom_components/ecoflow_cloud/api/ecoflow_mqtt.py custom_components/ecoflow_cloud/api/__init__.py custom_components/ecoflow_cloud/devices/data_holder.py custom_components/ecoflow_cloud/devices/status_coordinator.py custom_components/ecoflow_cloud/entities/__init__.py custom_components/ecoflow_cloud/sensor.py custom_components/ecoflow_cloud/devices/internal/river2.py custom_components/ecoflow_cloud/devices/internal/river2_max.py custom_components/ecoflow_cloud/devices/internal/river2_pro.py`
- `python3 -m py_compile custom_components/ecoflow_cloud/api/ecoflow_mqtt.py custom_components/ecoflow_cloud/api/__init__.py custom_components/ecoflow_cloud/devices/data_holder.py custom_components/ecoflow_cloud/devices/status_coordinator.py custom_components/ecoflow_cloud/entities/__init__.py custom_components/ecoflow_cloud/sensor.py custom_components/ecoflow_cloud/devices/internal/river2.py custom_components/ecoflow_cloud/devices/internal/river2_max.py custom_components/ecoflow_cloud/devices/internal/river2_pro.py`
- `git diff --check`
- GitHub checks are passing on the current head: HACS validation, lint, and
  hassfest validation.
