### PR TITLE
fix: stop sensor value flip when device is offline

### DIFF
--- a/custom_components/ecoflow_cloud/devices/status_tracker.py
+++ b/custom_components/ecoflow_cloud/devices/status_tracker.py
@@ -80,8 +80,8 @@ class StatusTracker:
 
     @property
     def wants_status_poll(self) -> bool:
-        """True when status is uncertain and an explicit poll would help clarify."""
-        return self.status == OnlineStatus.ASSUME_OFFLINE
+        """True when status is uncertain or offline and an explicit poll would help clarify."""
+        return not self.is_online
 
     @property
     def last_data_time(self) -> datetime:

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -108,6 +108,7 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         self._attr_available = enabled
         self.__attributes_mapping: dict[str, str] = {}
         self.__attrs = OrderedDict[str, Any]()
+        self._reset_done: bool = False
         if diagnostic is not None:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC if diagnostic else None
 
@@ -140,13 +141,22 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         # self.async_on_remove(d.dispose)
 
     def _handle_coordinator_update(self) -> None:
-        if self.coordinator.data.changed:
-            self._updated(self.coordinator.data.data_holder.params)
-        elif self._device.status_tracker.is_offline:  # Device is offline
-            # Reset sensors that should reset to default values
+        params = self.coordinator.data.data_holder.params
+        is_offline = self._device.status_tracker.is_offline
+
+        if is_offline and not self._reset_done:
             if isinstance(self, BaseSensorEntity) and self._attr_default_value is not None:
-                self._mqtt_key_expr.update(self.coordinator.data.data_holder.params, self._attr_default_value)
-                self._updated(self.coordinator.data.data_holder.params)
+                self._mqtt_key_expr.update(params, self._attr_default_value)
+                self._reset_done = True
+            # fall through to _updated() to publish the reset value
+        elif is_offline:
+            return  # already reset, ignore all ticks (including cached quota data) until back online
+        elif self._reset_done:
+            self._reset_done = False  # first tick back online — restore immediately
+        elif not self.coordinator.data.changed:
+            return  # online, no new data
+
+        self._updated(params)
 
     def _updated(self, data: dict[str, Any]):
         # update attributes


### PR DESCRIPTION
### Problem

Two related regressions introduced in v1.5.0 affect devices connected via the public API (e.g. PowerStream) that have no MQTT heartbeat:

**1. Sensor values flipping between real values and zero every 30–60 seconds while offline**

The `_handle_coordinator_update` reset logic fired on **every** coordinator tick while `is_offline`. Meanwhile, `quota_all()` continues polling the EcoFlow REST API on a scheduled interval — and the API returns cached data regardless of actual device status. Each quota response bumped `changed=True` for one tick, temporarily restoring real sensor values, before the next tick reset them back to zero. This caused continuous flipping for the entire offline period.

**2. Device stuck permanently offline once it passed through the `ASSUME_OFFLINE` window**

The `DeviceStatusCoordinator` polls `/device/list` to recover online status, but only when `wants_status_poll` is `True` — which was exclusively the case for `ASSUME_OFFLINE`. If the coordinator tick missed the `ASSUME_OFFLINE` window and the tracker decayed to full `OFFLINE`, `wants_status_poll` returned `False`, the poll was permanently skipped, and the device could not recover without a full HA restart.

### Root cause context

The v1.5.0 changes were a deliberate fix for a v1.4.1 bug where `/device/quota/all` returning cached data for offline devices caused `online=True` to be set unconditionally, meaning devices never showed as offline. The `is_auto=False` flag on quota `PreparedData` was the correct fix for that — but the recovery and reset mechanisms did not account for public-API-only devices that have no MQTT activity.

### Fix

**`devices/status_tracker.py`** — extend `wants_status_poll` to include `OFFLINE`:

```python
@property
def wants_status_poll(self) -> bool:
    return not self.is_online  # ASSUME_OFFLINE and OFFLINE both need a poll
```

The `StatusCoordinator` interval is already set to `assume_offline_sec` (default 5 min), so this adds at most one `/device/list` call per interval with no meaningful API overhead. Maximum recovery time after a device comes back online: ~5 minutes.


**`entities/__init__.py`** — fire the offline reset once, suppress cached quota data while offline, and restore immediately on recovery.

Key behaviours:
- Reset fires **once** on the first `OFFLINE` tick, then the entity is frozen at the default value
- Subsequent ticks while offline — including `changed=True` ticks from cached quota data — are ignored entirely
- On the first tick after the device comes back online, params are restored **immediately** without waiting for the next quota poll

### Behaviour summary

| Scenario | Before (v1.5.0) | After this fix |
|---|---|---|
| Sensors while offline | Flip between real values and 0 every ~30–60s | Reset to 0 once, stable for entire offline period |
| Device offline past `ASSUME_OFFLINE` window | Stuck offline permanently | Recovered within ~5 min of coming back online |
| Device comes back online | Values restored on next quota poll (sensors may show 0 in the gap) | Values restored on first coordinator tick after status poll |