### PR TITLE
fix(delta3): silence noisy base64 decode debug logs

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3.py
@@ -568,8 +568,9 @@ class Delta3(BaseInternalDevice):
 
             try:
                 raw_data = base64.b64decode(raw_data, validate=True)
-            except Exception as e:
-                _LOGGER.debug("[Delta3] get_reply base64 decode failed: %s", e)
+            except Exception:
+                # Most payloads are raw protobuf, not base64; silent fall-through.
+                pass
 
             header_msg = delta3_pb2.Delta3HeaderMessage()
             header_msg.ParseFromString(raw_data)
@@ -612,9 +613,9 @@ class Delta3(BaseInternalDevice):
             try:
                 decoded_payload = base64.b64decode(raw_data, validate=True)
                 raw_data = decoded_payload
-            except Exception as e:
-                # If base64 decoding fails, proceed with the original raw_data (it may not be base64 encoded)
-                _LOGGER.debug("[Delta3] base64 decode failed: %s", e)
+            except Exception:
+                # Most payloads are raw protobuf, not base64; silent fall-through.
+                pass
 
             try:
                 header_msg = delta3_pb2.Delta3HeaderMessage()
@@ -832,9 +833,9 @@ class Delta3(BaseInternalDevice):
             try:
                 decoded_payload = base64.b64decode(raw_data, validate=True)
                 raw_data = decoded_payload
-            except Exception as e:
-                # If base64 decoding fails, proceed with the original raw_data (it may not be base64 encoded)
-                _LOGGER.debug("[Delta3] base64 decode failed: %s", e)
+            except Exception:
+                # Most payloads are raw protobuf, not base64; silent fall-through.
+                pass
 
             header_msg = delta3_pb2.Delta3SendHeaderMsg()
             header_msg.ParseFromString(raw_data)


### PR DESCRIPTION
These three `except` branches in `devices/internal/delta3.py` fired for every protobuf payload because the messages are raw protobuf, not base64-encoded. The logs flooded debug output without conveying useful information.

The fall-through behavior (use the raw payload when base64 decoding fails) is unchanged — only the per-message `_LOGGER.debug` call is removed and replaced with a short comment explaining why.