### PR TITLE
fix(mqtt): handle auth failures gracefully and add reauth flow

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -6,7 +6,7 @@ from typing import Final
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from . import _preload_proto  # noqa: F401 # pyright: ignore[reportUnusedImport]
 from .device_data import DeviceData, DeviceOptions
@@ -203,6 +203,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # Transient network issues - retry later
         _LOGGER.warning("Failed to connect to EcoFlow API: %s", ex)
         raise ConfigEntryNotReady(f"Connection failed: {ex}") from ex
+    except Exception as ex:
+        from .api import EcoflowAuthException
+
+        if isinstance(ex, EcoflowAuthException):
+            _LOGGER.error("EcoFlow credentials rejected: %s", ex)
+            raise ConfigEntryAuthFailed(str(ex)) from ex
+        _LOGGER.warning("EcoFlow login failed: %s", ex)
+        raise ConfigEntryNotReady(f"Login failed: {ex}") from ex
 
     # Fetch current device statuses from API
     try:
@@ -216,7 +224,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         device = api_client.configure_device(device_data, api_devices_map)
         device.configure(hass)
 
-    await hass.async_add_executor_job(api_client.start)
+    await hass.async_add_executor_job(api_client.start, hass, entry.entry_id)
     hass.data[ECOFLOW_DOMAIN][entry.entry_id] = api_client
 
     # Must load all device data before configuring devices because the data

--- a/custom_components/ecoflow_cloud/api/__init__.py
+++ b/custom_components/ecoflow_cloud/api/__init__.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from aiohttp import ClientResponse
 from attr import dataclass
+from homeassistant.core import HomeAssistant
 
 from ..device_data import DeviceData
 from .message import JSONMessage, Message
@@ -13,6 +14,10 @@ _LOGGER = logging.getLogger(__name__)
 
 class EcoflowException(Exception):
     pass
+
+
+class EcoflowAuthException(EcoflowException):
+    """Raised when EcoFlow API rejects credentials (access/secret keys or username/password)."""
 
 
 @dataclass
@@ -31,6 +36,10 @@ class EcoflowApiClient(ABC):
         self.mqtt_info: EcoflowMqttInfo
         self.devices: dict[str, Any] = {}
         self.mqtt_client: EcoflowMQTTClient
+        self.hass: HomeAssistant | None = None
+        self.entry_id: str | None = None
+        self._auth_refresh_in_progress = False
+        self._consecutive_auth_failures = 0
 
     @abstractmethod
     async def login(self):
@@ -98,6 +107,8 @@ class EcoflowApiClient(ABC):
         _LOGGER.info(f"Successfully extracted account: {self.mqtt_info.username}")
 
     async def _get_json_response(self, resp: ClientResponse) -> dict[str, Any]:
+        if resp.status in (401, 403):
+            raise EcoflowAuthException(f"HTTP {resp.status}: {resp.reason}")
         if resp.status != 200:
             raise EcoflowException(f"Got HTTP status code {resp.status}: {resp.reason}")
 
@@ -110,6 +121,22 @@ class EcoflowApiClient(ABC):
             raise EcoflowException(f"Failed to parse response: {resp.text} Error: {error}")
 
         if response_message.lower() != "success":
+            lowered = response_message.lower()
+            if any(
+                kw in lowered
+                for kw in (
+                    "unauthor",
+                    "access denied",
+                    "accesskey",
+                    "secretkey",
+                    "invalid sign",
+                    "sign error",
+                    "incorrect password",
+                    "account doesn't exist",
+                    "token",
+                )
+            ):
+                raise EcoflowAuthException(response_message)
             raise EcoflowException(f"{response_message}")
 
         return json_resp
@@ -127,11 +154,106 @@ class EcoflowApiClient(ABC):
         self.devices[device_sn].data.update_to_target_state(mqtt_state)
         self.mqtt_client.publish(self.devices[device_sn].device_info.set_topic, command.to_mqtt_payload())
 
-    def start(self):
+    def start(self, hass: HomeAssistant | None = None, entry_id: str | None = None):
         _LOGGER.debug("Starting MQTT client for %s", self.mqtt_info.client_id)
         from custom_components.ecoflow_cloud.api.ecoflow_mqtt import EcoflowMQTTClient
 
-        self.mqtt_client = EcoflowMQTTClient(self.mqtt_info, self.devices)
+        if hass is not None:
+            self.hass = hass
+        if entry_id is not None:
+            self.entry_id = entry_id
+
+        self.mqtt_client = EcoflowMQTTClient(
+            self.mqtt_info,
+            self.devices,
+            auth_failure_callback=self._on_mqtt_auth_failure,
+            connect_success_callback=self._on_mqtt_connect_success,
+        )
+
+    def _on_mqtt_auth_failure(self) -> None:
+        # Called from paho thread. Hop to the event loop to refresh credentials.
+        if self.hass is None:
+            _LOGGER.error("MQTT auth failure but no HomeAssistant reference; cannot refresh credentials")
+            return
+        if self._auth_refresh_in_progress:
+            return
+        self.hass.loop.call_soon_threadsafe(
+            lambda: self.hass.async_create_task(self._async_refresh_credentials())
+        )
+
+    def _on_mqtt_connect_success(self) -> None:
+        self._consecutive_auth_failures = 0
+
+    async def _async_refresh_credentials(self) -> None:
+        import asyncio
+
+        if self._auth_refresh_in_progress:
+            return
+        self._auth_refresh_in_progress = True
+        try:
+            self._consecutive_auth_failures += 1
+
+            # Polite backoff so we never poke the broker faster than once a
+            # minute on an auth-fail loop. EcoFlow's broker appears to throttle
+            # / temp-ban accounts that reconnect too aggressively.
+            backoff = {1: 30, 2: 60, 3: 180, 4: 300}.get(self._consecutive_auth_failures, 300)
+            if self._consecutive_auth_failures > 4:
+                _LOGGER.error(
+                    "MQTT auth keeps failing for %s after %d refreshes; triggering reauth",
+                    self.mqtt_info.client_id,
+                    self._consecutive_auth_failures,
+                )
+                self._trigger_reauth()
+                return
+
+            _LOGGER.info(
+                "Waiting %ds before refreshing EcoFlow MQTT credentials (attempt %d)",
+                backoff,
+                self._consecutive_auth_failures,
+            )
+            await asyncio.sleep(backoff)
+
+            _LOGGER.info(
+                "Refreshing EcoFlow MQTT credentials (attempt %d)", self._consecutive_auth_failures
+            )
+            try:
+                await self.login()
+            except EcoflowAuthException as ex:
+                _LOGGER.error("Credential refresh failed (auth): %s", ex)
+                self._trigger_reauth()
+                return
+            except Exception as ex:  # noqa: BLE001
+                _LOGGER.warning("Credential refresh failed: %s", ex)
+                return
+
+            try:
+                await self.hass.async_add_executor_job(self._restart_mqtt_with_new_credentials)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to restart MQTT client with refreshed credentials")
+        finally:
+            self._auth_refresh_in_progress = False
+
+    def _restart_mqtt_with_new_credentials(self) -> None:
+        try:
+            self.mqtt_client.stop()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Error while stopping MQTT client during credential refresh", exc_info=True)
+        from custom_components.ecoflow_cloud.api.ecoflow_mqtt import EcoflowMQTTClient
+
+        self.mqtt_client = EcoflowMQTTClient(
+            self.mqtt_info,
+            self.devices,
+            auth_failure_callback=self._on_mqtt_auth_failure,
+            connect_success_callback=self._on_mqtt_connect_success,
+        )
+
+    def _trigger_reauth(self) -> None:
+        if self.hass is None or self.entry_id is None:
+            return
+        entry = self.hass.config_entries.async_get_entry(self.entry_id)
+        if entry is None:
+            return
+        self.hass.loop.call_soon_threadsafe(entry.async_start_reauth, self.hass)
 
     def stop(self):
         _LOGGER.debug("Stopping MQTT client for %s", self.mqtt_info.client_id)

--- a/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
+++ b/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import ssl
-from typing import Any
+from typing import Any, Callable
 
 from homeassistant.core import callback
 from paho.mqtt.client import Client, ConnectFlags, DisconnectFlags, MQTTMessage, PayloadType
@@ -15,12 +15,24 @@ from . import EcoflowMqttInfo
 
 _LOGGER = logging.getLogger(__name__)
 
+# MQTT v3.1.1 CONNACK code 5 / v5 reason code names that indicate auth failure
+_AUTH_FAILURE_NAMES = {"Not authorized", "Bad user name or password", "Banned"}
+
 
 class EcoflowMQTTClient:
-    def __init__(self, mqtt_info: EcoflowMqttInfo, devices: dict[str, BaseDevice]):
+    def __init__(
+        self,
+        mqtt_info: EcoflowMqttInfo,
+        devices: dict[str, BaseDevice],
+        auth_failure_callback: Callable[[], None] | None = None,
+        connect_success_callback: Callable[[], None] | None = None,
+    ):
         self.connected = False
         self.__mqtt_info = mqtt_info
         self.__devices: dict[str, BaseDevice] = devices
+        self.__auth_failure_callback = auth_failure_callback
+        self.__connect_success_callback = connect_success_callback
+        self.__auth_failure_notified = False
 
         from homeassistant.components.mqtt.async_client import AsyncMQTTClient
 
@@ -36,6 +48,10 @@ class EcoflowMQTTClient:
         self.__client.username_pw_set(self.__mqtt_info.username, self.__mqtt_info.password)
         self.__client.tls_set(certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED)
         self.__client.tls_insecure_set(False)
+        # Be polite to the EcoFlow broker: don't hammer reconnects.
+        # Defaults are min=1s, max=120s; we use 30s -> 300s to avoid tripping
+        # any per-account connection rate limits on transient drops.
+        self.__client.reconnect_delay_set(min_delay=30, max_delay=300)
         self.__client.on_connect = self._on_connect
         self.__client.on_disconnect = self._on_disconnect
         self.__client.on_message = self._on_message
@@ -71,11 +87,19 @@ class EcoflowMQTTClient:
     ):
         if rc == 0:
             self.connected = True
+            self.__auth_failure_notified = False
             target_topics = [(topic, 1) for topic in self.__target_topics()]
             self.__client.subscribe(target_topics)
             _LOGGER.info(f"Subscribed to MQTT topics {target_topics}")
+            if self.__connect_success_callback is not None:
+                try:
+                    self.__connect_success_callback()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Connect success callback raised")
         else:
             self.__log_with_reason("connect", client, userdata, rc)
+            if rc.getName() in _AUTH_FAILURE_NAMES:
+                self.__handle_auth_failure()
 
     @callback
     def _on_disconnect(
@@ -110,6 +134,32 @@ class EcoflowMQTTClient:
         self.__client.unsubscribe(self.__target_topics())
         self.__client.loop_stop()
         self.__client.disconnect()
+
+    def __handle_auth_failure(self) -> None:
+        # MQTT broker rejected our credentials. The token from /certification is
+        # short-lived; ask the API client to refresh it. Stop paho's reconnect loop
+        # so it doesn't keep hammering with stale creds.
+        if self.__auth_failure_notified:
+            return
+        self.__auth_failure_notified = True
+        _LOGGER.warning(
+            "MQTT credentials rejected for %s; pausing reconnect loop and requesting refresh",
+            self.__mqtt_info.client_id,
+        )
+        try:
+            self.__client.loop_stop()
+        except Exception:  # noqa: BLE001
+            pass
+        if self.__auth_failure_callback is not None:
+            try:
+                self.__auth_failure_callback()
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Auth failure callback raised")
+
+    def update_credentials(self, mqtt_info: EcoflowMqttInfo) -> None:
+        self.__mqtt_info = mqtt_info
+        self.__client.username_pw_set(mqtt_info.username, mqtt_info.password)
+        self.__auth_failure_notified = False
 
     def __log_with_reason(self, action: str, client, userdata, reason_code: ReasonCode):
         _LOGGER.error(f"MQTT {action}: {reason_code.getName()} ({self.__mqtt_info.client_id}) - {userdata}")

--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -178,6 +178,18 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
         self.set_current_config_entry(self.hass.config_entries.async_get_entry(self.context["entry_id"]))
         return await self.async_step_user()
 
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> Any:
+        """Handle re-authentication when credentials are rejected."""
+        self.set_current_config_entry(self.hass.config_entries.async_get_entry(self.context["entry_id"]))
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> Any:
+        if self.config_entry is None:
+            return self.async_abort(reason="reauth_failed")
+        if CONF_ACCESS_KEY in self.config_entry.data:
+            return await self.async_step_api(user_input)
+        return await self.async_step_manual(user_input)
+
     async def async_step_choose_type(self, user_input: dict[str, Any] | None = None):
         if self.config_entry:  # reconfig flow
             if CONF_ACCESS_KEY in self.config_entry.data:


### PR DESCRIPTION
## Problem

The MQTT credentials returned by the Open API ``/certification`` endpoint are short-lived. Once they expire (or are rejected for any other reason), paho-mqtt's ``reconnect_on_failure=True`` loop kept retrying with the same stale credentials forever, producing this every ~30 seconds with no recovery path:

```
MQTT disconnect: Unspecified error (Hassio-open-…)
MQTT connect: Not authorized (Hassio-open-…)
```

The integration also had no way to surface a permanently-bad AccessKey/SecretKey to the user — they just saw a noisy log and a non-working integration until they restarted HA and reconfigured manually.

## Changes

* **Detect auth-failure connacks** in ``EcoflowMQTTClient`` (``Not authorized``, ``Bad user name or password``, ``Banned``). On the first such connack we log a single warning, call ``loop_stop()`` to break paho's retry loop, and notify the API client via a new ``auth_failure_callback``.
* **Refresh credentials** in ``EcoflowApiClient`` by re-running ``login()`` from the event loop, then rebuild the MQTT client with the new credentials.
* **Back off** retries (30s → 60s → 180s → 300s) before each refresh attempt so the broker is never hammered.
* **Escalate to reauth** after 5 consecutive failed refreshes by raising ``ConfigEntryAuthFailed`` via ``entry.async_start_reauth(hass)``. The user gets a normal HA reauth flow in the UI instead of a silently broken integration.
* **New reauth flow steps** ``async_step_reauth`` / ``async_step_reauth_confirm`` in ``config_flow.py`` route to the existing ``async_step_api`` (public API) or ``async_step_manual`` (private API) with previous values pre-filled.
* **Slow paho's own reconnect** with ``reconnect_delay_set(min_delay=30, max_delay=300)`` so any transient network failure also avoids hammering the broker.
* **Convert initial-setup auth failures** to ``ConfigEntryAuthFailed`` in ``async_setup_entry`` so HA surfaces them properly with a reauth notification.

## Notes

* All callbacks dispatched from the paho thread hop to the HA event loop with ``hass.loop.call_soon_threadsafe`` to avoid touching ``hass.data`` from a non-loop thread.
* No behavior change for healthy connections — the new code paths only fire on auth-failure connacks.
* Tested against an mHome (public API) entry running a Delta Pro Ultra and an mGomeA (private API) entry running a Delta 3 + River 3.