### PR TITLE
fix(status): keep scheduled status entity id stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2207,7 +2207,7 @@ For information on how to add, remove, and configure devices, please refer to th
 - Wireless Warning Code  _(disabled)_
 - LED Brightness  _(disabled)_
 - Heartbeat Frequency  _(disabled)_
-- Status (Scheduled)
+- Status
 
 *Sliders (numbers)*
 - Min Discharge Level
@@ -2966,7 +2966,6 @@ For information on how to add, remove, and configure devices, please refer to th
 - mpptPv2.pwr
 - mpptPv2.amp
 - mpptPv2.vol
-- Status (Scheduled)
+- Status
 
 </p></details>
-

--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 
 from . import _preload_proto  # noqa: F401 # pyright: ignore[reportUnusedImport]
 from .device_data import DeviceData, DeviceOptions
@@ -14,7 +15,7 @@ from .device_data import DeviceData, DeviceOptions
 _LOGGER = logging.getLogger(__name__)
 
 ECOFLOW_DOMAIN = "ecoflow_cloud"
-CONFIG_VERSION = 10
+CONFIG_VERSION = 11
 
 _PLATFORMS = {
     Platform.BINARY_SENSOR,
@@ -64,6 +65,23 @@ DEFAULT_REFRESH_PERIOD_SEC: Final = 5
 DEFAULT_ASSUME_OFFLINE_SEC: Final = 300  # 5 minutes
 
 _STATUS_COORDINATOR_KEY = "__status_coordinator"
+
+
+def _migrate_entity_unique_id(
+    hass: HomeAssistant,
+    platform: Platform,
+    old_unique_id: str,
+    new_unique_id: str,
+) -> bool:
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(platform, ECOFLOW_DOMAIN, old_unique_id)
+    if entity_id is None:
+        return False
+    if registry.async_get_entity_id(platform, ECOFLOW_DOMAIN, new_unique_id) is not None:
+        return False
+
+    registry.async_update_entity(entity_id, new_unique_id=new_unique_id)
+    return True
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -135,6 +153,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             device_options[OPTS_ASSUME_OFFLINE_SEC] = DEFAULT_ASSUME_OFFLINE_SEC
 
         updated = hass.config_entries.async_update_entry(config_entry, version=10, options=new_options)
+        _LOGGER.info("Config entries updated to version %d", config_entry.version)
+
+    if config_entry.version == 10:
+        if CONF_ACCESS_KEY in config_entry.data:
+            for sn, device_info in config_entry.data[CONF_DEVICE_LIST].items():
+                if device_info[CONF_DEVICE_TYPE] not in ("PowerStream", "Power Ocean"):
+                    continue
+
+                migrated = _migrate_entity_unique_id(
+                    hass,
+                    Platform.SENSOR,
+                    f"ecoflow-api-{sn}-status-scheduled",
+                    f"ecoflow-api-{sn}-status",
+                )
+                if migrated:
+                    _LOGGER.info("Migrated scheduled status entity unique ID for %s", sn)
+
+        updated = hass.config_entries.async_update_entry(config_entry, version=11)
         _LOGGER.info("Config entries updated to version %d", config_entry.version)
 
     return updated

--- a/custom_components/ecoflow_cloud/devices/public/powerocean.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerocean.py
@@ -226,7 +226,7 @@ class PowerOcean(BaseDevice):
 
     def _status_sensor(self, client: EcoflowApiClient) -> QuotaScheduledStatusSensorEntity:
         # Keep quota fallback active even while MQTT stream is sparse.
-        return QuotaScheduledStatusSensorEntity(client, self, 60)
+        return QuotaScheduledStatusSensorEntity(client, self, 60, "Status", "status")
 
     def _flatten_param_branch(self, prefix: str, value: Any, target: dict[str, Any]) -> None:
         if isinstance(value, dict):

--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -195,4 +195,4 @@ class PowerStream(BaseDevice):
 
     def _status_sensor(self, client: EcoflowApiClient) -> QuotaScheduledStatusSensorEntity:
         # Keep quota fallback active even while MQTT stream is sparse.
-        return QuotaScheduledStatusSensorEntity(client, self, 60)
+        return QuotaScheduledStatusSensorEntity(client, self, 60, "Status", "status")

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -580,8 +580,15 @@ class QuotaStatusSensorEntity(StatusSensorEntity):
 class QuotaScheduledStatusSensorEntity(QuotaStatusSensorEntity):
     """QuotaStatusSensorEntity with additional periodic scheduled refresh."""
 
-    def __init__(self, client: EcoflowApiClient, device: BaseDevice, reload_delay: int = 3600):
-        super().__init__(client, device, "Status (Scheduled)", "status.scheduled")
+    def __init__(
+        self,
+        client: EcoflowApiClient,
+        device: BaseDevice,
+        reload_delay: int = 3600,
+        title: str = "Status (Scheduled)",
+        key: str = "status.scheduled",
+    ):
+        super().__init__(client, device, title, key)
         self._scheduled_refresh_sec = reload_delay
 
 

--- a/docs/devices/PowerStream-Public.md
+++ b/docs/devices/PowerStream-Public.md
@@ -58,7 +58,7 @@
 - Wireless Warning Code (`20_1.wirelessWarnCode`)   _(disabled)_
 - LED Brightness (`20_1.invBrightness`)   _(disabled)_
 - Heartbeat Frequency (`20_1.heartbeatFrequency`)   _(disabled)_
-- Status (Scheduled)
+- Status
 
 *Sliders (numbers)*
 - Min Discharge Level (`20_1.lowerLimit` -> `{"sn": "SN", "cmdCode": "WN511_SET_BAT_LOWER_PACK", "params": {"lowerLimit": "VALUE"}}` [0 - 30])
@@ -68,5 +68,4 @@
 
 *Selects*
 - Power supply mode (`20_1.supplyPriority` -> `{"sn": "SN", "cmdCode": "WN511_SET_SUPPLY_PRIORITY_PACK", "params": {"supplyPriority": "VALUE"}}` [Prioritize power supply (0), Prioritize power storage (1)])
-
 

--- a/docs/devices/Power_Ocean-Public.md
+++ b/docs/devices/Power_Ocean-Public.md
@@ -23,6 +23,5 @@
 - mpptPv2.pwr (`96_1.mpptHeartBeat[0].mpptPv[1].pwr`)
 - mpptPv2.amp (`96_1.mpptHeartBeat[0].mpptPv[1].amp`)
 - mpptPv2.vol (`96_1.mpptHeartBeat[0].mpptPv[1].vol`)
-- Status (Scheduled)
-
+- Status
 

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -2168,7 +2168,7 @@
 - Wireless Warning Code  _(disabled)_
 - LED Brightness  _(disabled)_
 - Heartbeat Frequency  _(disabled)_
-- Status (Scheduled)
+- Status
 
 *Sliders (numbers)*
 - Min Discharge Level
@@ -2927,8 +2927,7 @@
 - mpptPv2.pwr
 - mpptPv2.amp
 - mpptPv2.vol
-- Status (Scheduled)
+- Status
 
 </p></details>
-
 


### PR DESCRIPTION
## Summary
- keep scheduled quota refresh for public PowerStream and Power Ocean while restoring the standard Status title and unique ID
- migrate existing public PowerStream and Power Ocean entity registry entries from status-scheduled to status
- update generated device docs and summary for the restored Status entity

Fixes #754.

## Validation
- python -m compileall -q custom_components/ecoflow_cloud
- python -m ruff check custom_components/ecoflow_cloud
- git diff --check origin/main...HEAD
- codex review --base origin/main
