### PR TITLE
Stream AC Pro: protobuf bidirectional control and state decoding

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -277,6 +277,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
+    # Stream AC Pro schedule write service — extends Phase E to allow
+    # arbitrary edits of the SetTimeTaskWrite at field 595, not just the
+    # enable bit. Wire format derived from the EcoFlow app capture
+    # session 2026-05-26. See docs/stream_ac_proto_fields.md.
+    if not hass.services.has_service(ECOFLOW_DOMAIN, "stream_ac_set_schedule"):
+        from homeassistant.core import ServiceCall
+
+        async def _stream_ac_set_schedule(call: ServiceCall) -> None:
+            serial = call.data["serial"]
+            for stored in hass.data.get(ECOFLOW_DOMAIN, {}).values():
+                if not isinstance(stored, EcoflowApiClient):
+                    continue
+                device = stored.devices.get(serial)
+                if device is None or not hasattr(device, "_build_proto_schedule_command"):
+                    continue
+                raw = device._build_proto_schedule_command(
+                    task_index=call.data.get("task_index", 2),
+                    enabled=call.data.get("enabled", True),
+                    is_valid=call.data.get("is_valid", True),
+                    is_repeating=call.data.get("is_repeating", False),
+                    time_mode=call.data.get("time_mode", 2),
+                    days=call.data.get("days", 0),
+                    start_min=call.data.get("start_min", 0),
+                    end_min=call.data.get("end_min", 0),
+                    power=call.data.get("power", 0),
+                )
+                stored.mqtt_client.publish(device.device_info.set_topic, raw)
+                return
+            raise ValueError(f"No Stream AC Pro device found with serial {serial}")
+
+        hass.services.async_register(ECOFLOW_DOMAIN, "stream_ac_set_schedule", _stream_ac_set_schedule)
+
     return True
 
 

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -371,6 +371,16 @@ STREAM_OUT_POWER = "Out Power"
 STREAM_STR_OUT_POWER = "Out Power %s"
 STREAM_OPERATION_MODE_SELF_POWERED = "Operating mode - Self-powered"
 STREAM_OPERATION_MODE_AI_MODE = "Operating mode - AI Mode"
+STREAM_OPERATION_MODE = "Operating mode"
+# Map display label -> inner field number of cfgEnergyStrategyOperateMode (write
+# field 106) / energyStrategyOperateMode (read field 393). The four modes are
+# mutually exclusive; only one is active at a time.
+STREAM_OPERATION_MODE_OPTIONS = {
+    "Self-Powered": 1,
+    "Scheduled": 2,
+    "TOU": 3,
+    "Smart": 4,
+}
 STREAM_FEED_IN_CONTROL = "Feed-in control"
 
 ACCU_CHARGE_CAP = "Cumulative Capacity Charge (mAh)"

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -372,6 +372,8 @@ STREAM_STR_OUT_POWER = "Out Power %s"
 STREAM_OPERATION_MODE_SELF_POWERED = "Operating mode - Self-powered"
 STREAM_OPERATION_MODE_AI_MODE = "Operating mode - AI Mode"
 STREAM_OPERATION_MODE = "Operating mode"
+STREAM_SCHEDULE = "Schedule"
+STREAM_SCHEDULE_ENABLED = "Schedule enabled"
 # Map display label -> inner field number of cfgEnergyStrategyOperateMode (write
 # field 106) / energyStrategyOperateMode (read field 393). The four modes are
 # mutually exclusive; only one is active at a time.

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -384,6 +384,7 @@ STREAM_OPERATION_MODE_OPTIONS = {
     "Smart": 4,
 }
 STREAM_FEED_IN_CONTROL = "Feed-in control"
+STREAM_SEMI_AUTO_DISCHARGE = "Semi-automated discharge"
 
 ACCU_CHARGE_CAP = "Cumulative Capacity Charge (mAh)"
 ACCU_CHARGE_ENERGY = "Cumulative Energy Charge (Wh)"

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -328,8 +328,15 @@ class StreamAC(BaseInternalDevice):
 
     # moduleWifiRssi
     def numbers(self, client: EcoflowApiClient) -> list[NumberEntity]:
+        outer_self = self
+
+        class ProtoBackupReserveEntity(BatteryBackupLevel):
+            async def async_set_native_value(self_, value: float):
+                raw = outer_self._build_proto_command(102, int(value))
+                client.mqtt_client.publish(outer_self.device_info.set_topic, raw)
+
         return [
-            BatteryBackupLevel(
+            ProtoBackupReserveEntity(
                 client,
                 self,
                 "backupReverseSoc",
@@ -339,18 +346,7 @@ class StreamAC(BaseInternalDevice):
                 "cmsMinDsgSoc",
                 "cmsMaxChgSoc",
                 3,
-                lambda value: {
-                    "sn": self.device_info.sn,
-                    "cmdId": 17,
-                    "cmdFunc": 254,
-                    "dirDest": 1,
-                    "dirSrc": 1,
-                    "dest": 2,
-                    "needAck": True,
-                    "params": {
-                        "cfgBackupReverseSoc": int(value),
-                    },
-                },
+                lambda value: {},
             ),
         ]
 
@@ -387,6 +383,49 @@ class StreamAC(BaseInternalDevice):
 
     def selects(self, client: EcoflowApiClient) -> list[SelectEntity]:
         return []
+
+    _MANUAL_FIELD_MAP: dict = {
+        380: ("relay2Onoff", bool),
+        461: ("backupReverseSoc", int),
+        1628: ("feedGridMode", int),
+    }
+
+    def _decode_manual_fields(self, pdata: bytes, raw: dict) -> None:
+        """Extract specific unmapped protobuf varint fields from raw pdata bytes."""
+
+        def decode_varint(data, pos):
+            result, shift = 0, 0
+            while pos < len(data):
+                b = data[pos]
+                pos += 1
+                result |= (b & 0x7F) << shift
+                if not (b & 0x80):
+                    return result, pos
+                shift += 7
+            return result, pos
+
+        pos = 0
+        while pos < len(pdata):
+            try:
+                tag, pos = decode_varint(pdata, pos)
+                field_num = tag >> 3
+                wire_type = tag & 0x7
+                if wire_type == 0:
+                    value, pos = decode_varint(pdata, pos)
+                    if field_num in self._MANUAL_FIELD_MAP:
+                        name, cast = self._MANUAL_FIELD_MAP[field_num]
+                        raw["params"][name] = cast(value)
+                elif wire_type == 2:
+                    length, pos = decode_varint(pdata, pos)
+                    pos += length
+                elif wire_type == 5:
+                    pos += 4
+                elif wire_type == 1:
+                    pos += 8
+                else:
+                    break
+            except Exception:
+                break
 
     @override
     def _prepare_data(self, raw_data: bytes) -> dict[str, Any]:
@@ -443,6 +482,8 @@ class StreamAC(BaseInternalDevice):
                     # paquet Champ_cmd50_3
                     if packet.msg.cmd_id > 0:
                         self._parsedata(packet, stream_ac2.StreamACChamp_cmd50_3(), raw)
+
+                    self._decode_manual_fields(packet.msg.pdata, raw)
 
                     _LOGGER.info("Found %u fields", len(raw["params"]))
 

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -10,6 +10,7 @@ from homeassistant.util import utcnow
 
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import BaseInternalDevice, const
+from custom_components.ecoflow_cloud.number import BatteryBackupLevel
 from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     CumulativeCapacitySensorEntity,
@@ -23,6 +24,7 @@ from custom_components.ecoflow_cloud.sensor import (
     TempSensorEntity,
     WattsSensorEntity,
 )
+from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -281,12 +283,107 @@ class StreamAC(BaseInternalDevice):
             # "waterInFlag": 0,
         ]
 
+    def _build_proto_command(self, field_num: int, value: int) -> bytes:
+        """Build a protobuf command payload for Stream AC internal API."""
+        import time
+        from .proto import stream_ac_pb2
+
+        def encode_varint(n):
+            result = bytearray()
+            while True:
+                bits = n & 0x7F
+                n >>= 7
+                if n:
+                    result.append(0x80 | bits)
+                else:
+                    result.append(bits)
+                    break
+            return bytes(result)
+
+        def encode_field(fnum, val):
+            return encode_varint((fnum << 3) | 0) + encode_varint(val)
+
+        pdata = encode_field(6, int(time.time())) + encode_field(field_num, value)
+
+        import random
+        header = stream_ac_pb2.StreamACHeader()
+        header.src = 32
+        header.dest = 2
+        header.d_src = 1
+        header.d_dest = 1
+        header.cmd_func = 254
+        header.cmd_id = 17
+        header.data_len = len(pdata)
+        header.need_ack = 1
+        header.seq = random.randint(100000000, 999999999)
+        header.product_id = 58
+        header.version = 3
+        header.payload_ver = 1
+        setattr(header, "from", "Android")
+        header.pdata = pdata
+
+        msg = stream_ac_pb2.StreamACSendHeaderMsg()
+        msg.msg.CopyFrom(header)
+        return msg.SerializeToString()
+
     # moduleWifiRssi
     def numbers(self, client: EcoflowApiClient) -> list[NumberEntity]:
-        return []
+        return [
+            BatteryBackupLevel(
+                client,
+                self,
+                "backupReverseSoc",
+                const.BACKUP_RESERVE_LEVEL,
+                3,
+                95,
+                "cmsMinDsgSoc",
+                "cmsMaxChgSoc",
+                3,
+                lambda value: {
+                    "sn": self.device_info.sn,
+                    "cmdId": 17,
+                    "cmdFunc": 254,
+                    "dirDest": 1,
+                    "dirSrc": 1,
+                    "dest": 2,
+                    "needAck": True,
+                    "params": {
+                        "cfgBackupReverseSoc": int(value),
+                    },
+                },
+            ),
+        ]
 
     def switches(self, client: EcoflowApiClient) -> list[SwitchEntity]:
-        return []
+        from custom_components.ecoflow_cloud.switch import EnabledEntity
+
+        class ProtoEnabledEntity(EnabledEntity):
+            def __init__(self_, *args, field_num, enable_val, disable_val, **kwargs):
+                self_._field_num = field_num
+                self_._enable_val = enable_val
+                self_._disable_val = disable_val
+                super().__init__(*args, **kwargs)
+
+            def turn_on(self_, **kwargs):
+                raw = self._build_proto_command(self_._field_num, self_._enable_val)
+                client.mqtt_client.publish(self.device_info.set_topic, raw)
+
+            def turn_off(self_, **kwargs):
+                raw = self._build_proto_command(self_._field_num, self_._disable_val)
+                client.mqtt_client.publish(self.device_info.set_topic, raw)
+
+        return [
+            ProtoEnabledEntity(
+                client, self, "feedGridMode", const.STREAM_FEED_IN_CONTROL,
+                lambda value: {}, field_num=168, enable_val=1, disable_val=2,
+                enableValue=2, disableValue=1,
+            ),
+            ProtoEnabledEntity(
+                client, self, "relay2Onoff", const.MODE_AC1_ON,
+                lambda value: {}, field_num=380, enable_val=1, disable_val=0,
+                enableValue=True, disableValue=False,
+            ),
+        ]
 
     def selects(self, client: EcoflowApiClient) -> list[SelectEntity]:
         return []

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -24,6 +24,7 @@ from custom_components.ecoflow_cloud.sensor import (
     TempSensorEntity,
     WattsSensorEntity,
 )
+from custom_components.ecoflow_cloud.select import DictSelectEntity
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -487,20 +488,25 @@ class StreamAC(BaseInternalDevice):
                 lambda value: {}, field_num=168, enable_val=1, disable_val=2,
                 enableValue=2, disableValue=1,
             ),
+            # Field 380 is reused for two different things depending on direction:
+            #   Write (cfgWrite, top-level varint 0/1): AC1 relay toggle
+            #     (relay2Onoff). Empirically verified to click the relay in
+            #     commit 218ad96.
+            #   Read (DisplayPropertyUpload field 380): plugInInfoPvVol — PV1
+            #     input voltage as a fixed32 float, nested two levels deep
+            #     inside Champ_cmd21_3. Not surfaced by the current decoder
+            #     (it's not declared in stream_ac.proto and
+            #     _decode_manual_fields only walks the top level of pdata), so
+            #     this switch's state stays "unknown" until the user toggles
+            #     it. The _MANUAL_FIELD_MAP entry below is harmless but dead.
             ProtoEnabledEntity(
                 client, self, "relay2Onoff", const.MODE_AC1_ON,
                 lambda value: {}, field_num=380, enable_val=1, disable_val=0,
                 enableValue=True, disableValue=False,
             ),
-            # The energy-strategy modes are mutually exclusive on the device — a
-            # radio-button group, not independent booleans. The write field is 106
-            # (cfgEnergyStrategyOperateMode); the read field is 393
-            # (energyStrategyOperateMode). Captured from the EcoFlow mobile app:
-            # ON  sends inner field 1 = 1  (Self-Powered)
-            # OFF sends inner field 2 = 1  (the "Custom" mode in the app UI)
-            # Both messages include a trailing empty field 546, which the device
-            # requires as a commit marker. The device acks on /set_reply with
-            # is_ack=1, cmd_id=18, and the original seq.
+            # Legacy Self-Powered-only switch, superseded by the four-option
+            # Operating mode select below. Disabled by default for new installs
+            # but kept so existing users' automations don't break on upgrade.
             ProtoNestedEnabledEntity(
                 client, self,
                 "energyStrategyOperateMode.operateSelfPoweredOpen",
@@ -510,28 +516,88 @@ class StreamAC(BaseInternalDevice):
                 enable_inner_field_num=1,
                 disable_inner_field_num=2,
                 trailing_empty_field=546,
+                enabled=False,
                 enableValue=True, disableValue=False,
             ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[SelectEntity]:
-        return []
+        outer_self = self
+
+        class ProtoNestedRadioSelectEntity(DictSelectEntity):
+            """Select for a mutually-exclusive radio-button proto field group.
+
+            The ``value`` stored in ``options_dict`` is the inner-field number
+            inside the outer nested write — selecting an option writes that
+            inner field with value=1 (the "set this mode" signal). The device
+            echoes back the chosen mode by emitting the matching inner field
+            of the read sub-message; ``_decode_manual_fields`` translates that
+            into the ``active_key`` int that this entity binds to.
+            """
+
+            def __init__(self_, *args, outer_field_num, trailing_empty_field=None, **kwargs):
+                self_._outer_field_num = outer_field_num
+                self_._trailing_empty_field = trailing_empty_field
+                super().__init__(*args, **kwargs)
+
+            def select_option(self_, option: str) -> None:
+                inner_field_num = self_._options_dict[option]
+                raw = outer_self._build_proto_nested_command(
+                    self_._outer_field_num,
+                    inner_field_num,
+                    True,
+                    trailing_empty_field=self_._trailing_empty_field,
+                )
+                client.mqtt_client.publish(outer_self.device_info.set_topic, raw)
+                self_._current_option = option
+                self_.schedule_update_ha_state()
+
+        return [
+            # Operating mode — cfgEnergyStrategyOperateMode (write field 106) /
+            # energyStrategyOperateMode (read field 393). Four mutually
+            # exclusive modes; selecting one writes its inner field number
+            # with value=1, followed by an empty field 546 commit marker.
+            # The device acks on /set_reply with is_ack=1, cmd_id=18.
+            ProtoNestedRadioSelectEntity(
+                client, self,
+                "energyStrategyOperateMode.activeMode",
+                const.STREAM_OPERATION_MODE,
+                const.STREAM_OPERATION_MODE_OPTIONS,
+                lambda value: {},
+                outer_field_num=106,
+                trailing_empty_field=546,
+            ),
+        ]
 
     _MANUAL_FIELD_MAP: dict = {
         6: ("f32ShowSoc", int),
+        # See the field-380 note above ProtoEnabledEntity in switches(). This
+        # entry is currently dead because incoming field 380 lives two levels
+        # deep inside Champ_cmd21_3 (where the proto names it plugInInfoPvVol,
+        # a float), not at the top level walked by _decode_manual_fields.
         380: ("relay2Onoff", bool),
         461: ("backupReverseSoc", int),
         1628: ("feedGridMode", int),
     }
 
-    # Wire-type-2 (sub-message) fields whose inner varint fields we want
-    # surfaced into raw["params"]. Inner field 1 of field 393 is confirmed by
-    # write/echo round-trip; the other inner fields in the energy-strategy
-    # group are still unmapped and will continue to surface as
-    # STREAM_AC_BOOL_GROUP debug lines until identified.
-    _NESTED_FIELD_MAP: dict = {
+    # Radio-button-group sub-messages: outer field number → group definition.
+    # Inner fields in such a group are mutually exclusive; the device clears
+    # the others when one is set to 1. For each group:
+    #   active_key — synthetic top-level int key written into raw["params"],
+    #                whose value is the inner field number of the active mode.
+    #                Bind a select entity to this key.
+    #   flags      — inner_field_num → (mirrored_bool_name, cast). When an
+    #                inner field is observed with value=1, the matching flag
+    #                is set True and all other tracked flags are cleared.
+    _RADIO_GROUP_MAP: dict = {
         393: {
-            1: ("energyStrategyOperateMode.operateSelfPoweredOpen", bool),
+            "active_key": "energyStrategyOperateMode.activeMode",
+            "flags": {
+                1: ("energyStrategyOperateMode.operateSelfPoweredOpen", bool),
+                2: ("energyStrategyOperateMode.operateScheduledOpen", bool),
+                3: ("energyStrategyOperateMode.operateTouModeOpen", bool),
+                4: ("energyStrategyOperateMode.operateIntelligentScheduleModeOpen", bool),
+            },
         },
     }
 
@@ -563,12 +629,10 @@ class StreamAC(BaseInternalDevice):
                 elif wire_type == 2:
                     length, pos = decode_varint(pdata, pos)
                     sub_bytes = pdata[pos:pos + length]
-                    if field_num in self._NESTED_FIELD_MAP:
-                        # Mutually-exclusive (radio-button) inner fields: when one
-                        # tracked inner field is reported, mirror its value; when an
-                        # untracked inner field arrives with value=1, every tracked
-                        # flag in the same group is implicitly off.
-                        inner_map = self._NESTED_FIELD_MAP[field_num]
+                    if field_num in self._RADIO_GROUP_MAP:
+                        group = self._RADIO_GROUP_MAP[field_num]
+                        active_key = group["active_key"]
+                        flags = group["flags"]
                         sub_pos = 0
                         while sub_pos < len(sub_bytes):
                             try:
@@ -577,12 +641,30 @@ class StreamAC(BaseInternalDevice):
                                 inner_wire_type = inner_tag & 0x7
                                 if inner_wire_type == 0:
                                     inner_value, sub_pos = decode_varint(sub_bytes, sub_pos)
-                                    if inner_field_num in inner_map:
-                                        inner_name, inner_cast = inner_map[inner_field_num]
-                                        raw["params"][inner_name] = inner_cast(inner_value)
+                                    if inner_field_num in flags and inner_value:
+                                        # This is the active mode. Mirror all
+                                        # flags (this one True, others False)
+                                        # and record the active inner-field
+                                        # number for the select entity.
+                                        for fnum, (fname, fcast) in flags.items():
+                                            raw["params"][fname] = fcast(1 if fnum == inner_field_num else 0)
+                                        raw["params"][active_key] = inner_field_num
+                                    elif inner_field_num in flags:
+                                        # Explicit value=0: clear just this
+                                        # flag. The device sometimes emits
+                                        # 0-values alongside the new active
+                                        # inner field within the same message.
+                                        fname, fcast = flags[inner_field_num]
+                                        raw["params"][fname] = fcast(0)
                                     elif inner_value:
-                                        for tracked_name, tracked_cast in inner_map.values():
-                                            raw["params"][tracked_name] = tracked_cast(0)
+                                        # An untracked inner field is set:
+                                        # the device is in a mode we don't
+                                        # model. Clear all tracked flags so
+                                        # stale state doesn't linger; leave
+                                        # active_key unchanged (the select
+                                        # will keep its last known value).
+                                        for fname, fcast in flags.values():
+                                            raw["params"][fname] = fcast(0)
                                 else:
                                     break
                             except Exception:

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -326,6 +326,78 @@ class StreamAC(BaseInternalDevice):
         msg.msg.CopyFrom(header)
         return msg.SerializeToString()
 
+    def _build_proto_nested_command(
+        self,
+        outer_field_num: int,
+        inner_field_num: int,
+        value: bool,
+        trailing_empty_field: int | None = None,
+    ) -> bytes:
+        """Build a protobuf command with a nested length-delimited sub-message (wire type 2).
+
+        Used for grouped boolean fields like cfgEnergyStrategyOperateMode, where the
+        outer field is a sub-message containing one or more inner varint booleans.
+        Optionally appends a trailing empty length-delimited field (observed in the
+        EcoFlow mobile app's writes as field 546 — appears to act as a "commit"
+        marker the device requires before applying the change).
+        """
+        import time
+        from .proto import stream_ac_pb2
+
+        def encode_varint(n):
+            result = bytearray()
+            while True:
+                bits = n & 0x7F
+                n >>= 7
+                if n:
+                    result.append(0x80 | bits)
+                else:
+                    result.append(bits)
+                    break
+            return bytes(result)
+
+        def encode_field(fnum, val):
+            return encode_varint((fnum << 3) | 0) + encode_varint(val)
+
+        def encode_nested_field(outer_fnum, inner_fnum, val):
+            inner = encode_field(inner_fnum, int(bool(val)))
+            return (
+                encode_varint((outer_fnum << 3) | 2)
+                + encode_varint(len(inner))
+                + inner
+            )
+
+        def encode_empty_field(fnum):
+            return encode_varint((fnum << 3) | 2) + encode_varint(0)
+
+        pdata = encode_field(6, int(time.time())) + encode_nested_field(
+            outer_field_num, inner_field_num, value
+        )
+        if trailing_empty_field is not None:
+            pdata += encode_empty_field(trailing_empty_field)
+
+        import random
+        header = stream_ac_pb2.StreamACHeader()
+        header.src = 32
+        header.dest = 2
+        header.d_src = 1
+        header.d_dest = 1
+        header.cmd_func = 254
+        header.cmd_id = 17
+        header.data_len = len(pdata)
+        header.need_ack = 1
+        header.seq = random.randint(100000000, 999999999)
+        header.product_id = 58
+        header.version = 3
+        header.payload_ver = 1
+        setattr(header, "from", "Android")
+        header.pdata = pdata
+
+        msg = stream_ac_pb2.StreamACSendHeaderMsg()
+        msg.msg.CopyFrom(header)
+        _LOGGER.debug("NESTED_CMD hex=%s", msg.SerializeToString().hex())
+        return msg.SerializeToString()
+
     # moduleWifiRssi
     def numbers(self, client: EcoflowApiClient) -> list[NumberEntity]:
         outer_self = self
@@ -363,10 +435,51 @@ class StreamAC(BaseInternalDevice):
             def turn_on(self_, **kwargs):
                 raw = self._build_proto_command(self_._field_num, self_._enable_val)
                 client.mqtt_client.publish(self.device_info.set_topic, raw)
+                self_._attr_is_on = True
+                self_.schedule_update_ha_state()
 
             def turn_off(self_, **kwargs):
                 raw = self._build_proto_command(self_._field_num, self_._disable_val)
                 client.mqtt_client.publish(self.device_info.set_topic, raw)
+                self_._attr_is_on = False
+                self_.schedule_update_ha_state()
+
+        class ProtoNestedEnabledEntity(EnabledEntity):
+            def __init__(
+                self_, *args,
+                outer_field_num,
+                enable_inner_field_num,
+                disable_inner_field_num,
+                trailing_empty_field=None,
+                **kwargs,
+            ):
+                self_._outer_field_num = outer_field_num
+                self_._enable_inner_field_num = enable_inner_field_num
+                self_._disable_inner_field_num = disable_inner_field_num
+                self_._trailing_empty_field = trailing_empty_field
+                super().__init__(*args, **kwargs)
+
+            def turn_on(self_, **kwargs):
+                raw = self._build_proto_nested_command(
+                    self_._outer_field_num,
+                    self_._enable_inner_field_num,
+                    True,
+                    trailing_empty_field=self_._trailing_empty_field,
+                )
+                client.mqtt_client.publish(self.device_info.set_topic, raw)
+                self_._attr_is_on = True
+                self_.schedule_update_ha_state()
+
+            def turn_off(self_, **kwargs):
+                raw = self._build_proto_nested_command(
+                    self_._outer_field_num,
+                    self_._disable_inner_field_num,
+                    True,
+                    trailing_empty_field=self_._trailing_empty_field,
+                )
+                client.mqtt_client.publish(self.device_info.set_topic, raw)
+                self_._attr_is_on = False
+                self_.schedule_update_ha_state()
 
         return [
             ProtoEnabledEntity(
@@ -379,6 +492,26 @@ class StreamAC(BaseInternalDevice):
                 lambda value: {}, field_num=380, enable_val=1, disable_val=0,
                 enableValue=True, disableValue=False,
             ),
+            # The energy-strategy modes are mutually exclusive on the device — a
+            # radio-button group, not independent booleans. The write field is 106
+            # (cfgEnergyStrategyOperateMode); the read field is 393
+            # (energyStrategyOperateMode). Captured from the EcoFlow mobile app:
+            # ON  sends inner field 1 = 1  (Self-Powered)
+            # OFF sends inner field 2 = 1  (the "Custom" mode in the app UI)
+            # Both messages include a trailing empty field 546, which the device
+            # requires as a commit marker. The device acks on /set_reply with
+            # is_ack=1, cmd_id=18, and the original seq.
+            ProtoNestedEnabledEntity(
+                client, self,
+                "energyStrategyOperateMode.operateSelfPoweredOpen",
+                const.STREAM_OPERATION_MODE_SELF_POWERED,
+                lambda value: {},
+                outer_field_num=106,
+                enable_inner_field_num=1,
+                disable_inner_field_num=2,
+                trailing_empty_field=546,
+                enableValue=True, disableValue=False,
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[SelectEntity]:
@@ -389,6 +522,17 @@ class StreamAC(BaseInternalDevice):
         380: ("relay2Onoff", bool),
         461: ("backupReverseSoc", int),
         1628: ("feedGridMode", int),
+    }
+
+    # Wire-type-2 (sub-message) fields whose inner varint fields we want
+    # surfaced into raw["params"]. Inner field 1 of field 393 is confirmed by
+    # write/echo round-trip; the other inner fields in the energy-strategy
+    # group are still unmapped and will continue to surface as
+    # STREAM_AC_BOOL_GROUP debug lines until identified.
+    _NESTED_FIELD_MAP: dict = {
+        393: {
+            1: ("energyStrategyOperateMode.operateSelfPoweredOpen", bool),
+        },
     }
 
     def _decode_manual_fields(self, pdata: bytes, raw: dict) -> None:
@@ -418,6 +562,38 @@ class StreamAC(BaseInternalDevice):
                         raw["params"][name] = cast(value)
                 elif wire_type == 2:
                     length, pos = decode_varint(pdata, pos)
+                    sub_bytes = pdata[pos:pos + length]
+                    if field_num in self._NESTED_FIELD_MAP:
+                        # Mutually-exclusive (radio-button) inner fields: when one
+                        # tracked inner field is reported, mirror its value; when an
+                        # untracked inner field arrives with value=1, every tracked
+                        # flag in the same group is implicitly off.
+                        inner_map = self._NESTED_FIELD_MAP[field_num]
+                        sub_pos = 0
+                        while sub_pos < len(sub_bytes):
+                            try:
+                                inner_tag, sub_pos = decode_varint(sub_bytes, sub_pos)
+                                inner_field_num = inner_tag >> 3
+                                inner_wire_type = inner_tag & 0x7
+                                if inner_wire_type == 0:
+                                    inner_value, sub_pos = decode_varint(sub_bytes, sub_pos)
+                                    if inner_field_num in inner_map:
+                                        inner_name, inner_cast = inner_map[inner_field_num]
+                                        raw["params"][inner_name] = inner_cast(inner_value)
+                                    elif inner_value:
+                                        for tracked_name, tracked_cast in inner_map.values():
+                                            raw["params"][tracked_name] = tracked_cast(0)
+                                else:
+                                    break
+                            except Exception:
+                                break
+                    elif field_num not in self._MANUAL_FIELD_MAP:
+                        _LOGGER.info(
+                            "STREAM_AC_BOOL_GROUP field=%d len=%d hex=%s",
+                            field_num,
+                            length,
+                            sub_bytes.hex(),
+                        )
                     pos += length
                 elif wire_type == 5:
                     pos += 4

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -31,6 +31,37 @@ from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+# Power values for the Stream AC are decoded as floats. A field whose real
+# value is 0 occasionally decodes to a denormalized-float artifact (e.g.
+# -1.40129846432482e-45), which then surfaces verbatim on the power sensors.
+# Clamp any such near-zero float to a clean 0 so every power sensor on this
+# device reports 0 instead of the artifact.
+_POWER_CLAMP_THRESHOLD = 0.01
+
+
+def _clamp_small_watts(val: Any) -> Any:
+    if isinstance(val, float) and abs(val) < _POWER_CLAMP_THRESHOLD:
+        return 0
+    return val
+
+
+class StreamACWattsSensorEntity(WattsSensorEntity):
+    @override
+    def _update_value(self, val: Any) -> bool:
+        return super()._update_value(_clamp_small_watts(val))
+
+
+class StreamACInWattsSensorEntity(InWattsSensorEntity):
+    @override
+    def _update_value(self, val: Any) -> bool:
+        return super()._update_value(_clamp_small_watts(val))
+
+
+class StreamACOutWattsSensorEntity(OutWattsSensorEntity):
+    @override
+    def _update_value(self, val: Any) -> bool:
+        return super()._update_value(_clamp_small_watts(val))
+
 
 class StreamAC(BaseInternalDevice):
     def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
@@ -124,7 +155,7 @@ class StreamAC(BaseInternalDevice):
             # "gridCodeVersion": 10001,
             # "gridConnectionFreq": 49.974655,
             # "gridConnectionPower": -967.2364,
-            WattsSensorEntity(client, self, "gridConnectionPower", const.STREAM_POWER_AC),
+            StreamACWattsSensorEntity(client, self, "gridConnectionPower", const.STREAM_POWER_AC),
             # "gridConnectionSta": "PANEL_GRID_IN",
             # "gridConnectionVol": 235.34576,
             MilliVoltSensorEntity(client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False),
@@ -133,7 +164,7 @@ class StreamAC(BaseInternalDevice):
             # "heatfilmTemp": [],
             # "hwVer": "V0.0.0",
             # "inputWatts": 900,
-            InWattsSensorEntity(client, self, "inputWatts", const.STREAM_IN_POWER, False),
+            StreamACInWattsSensorEntity(client, self, "inputWatts", const.STREAM_IN_POWER, False),
             # "invNtcTemp3": 49,
             # "maxBpInput": 1050,
             # "maxBpOutput": 1200,
@@ -164,7 +195,7 @@ class StreamAC(BaseInternalDevice):
             # "num": 0,
             # "openBmsFlag": 1,
             # "outputWatts": 0,
-            OutWattsSensorEntity(client, self, "outputWatts", const.STREAM_OUT_POWER, False),
+            StreamACOutWattsSensorEntity(client, self, "outputWatts", const.STREAM_OUT_POWER, False),
             # "packSn": "BKxxxxx",
             # "plugInInfoPv2Amp": 0.0,
             # "plugInInfoPv2Flag": false,
@@ -180,36 +211,36 @@ class StreamAC(BaseInternalDevice):
             # "plugInInfoPvVol": 0.0,
             # "powConsumptionMeasurement": 2,
             # "powGetBpCms": 1915.0862,
-            WattsSensorEntity(client, self, "powGetBpCms", const.STREAM_POWER_BATTERY),
+            StreamACWattsSensorEntity(client, self, "powGetBpCms", const.STREAM_POWER_BATTERY),
             # "powGetPv": 0.0,
-            WattsSensorEntity(client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True),
+            StreamACWattsSensorEntity(client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True),
             # "powGetPv2": 0.0,
-            WattsSensorEntity(client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True),
+            StreamACWattsSensorEntity(client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True),
             # "powGetPv3": 0.0,
-            WattsSensorEntity(client, self, "powGetPv3", const.STREAM_POWER_PV_3, False, True),
+            StreamACWattsSensorEntity(client, self, "powGetPv3", const.STREAM_POWER_PV_3, False, True),
             # "powGetPv4": 0.0,
-            WattsSensorEntity(client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True),
+            StreamACWattsSensorEntity(client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True),
             # "powGetPvSum": 2051.3975,
-            WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM),
+            StreamACWattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM),
             # "powGetSchuko1": 0.0,
-            WattsSensorEntity(client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True),
+            StreamACWattsSensorEntity(client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True),
             # "powGetSchuko2": 18.654325,
-            WattsSensorEntity(client, self, "powGetSchuko2", const.STREAM_GET_SCHUKO2, False, True),
+            StreamACWattsSensorEntity(client, self, "powGetSchuko2", const.STREAM_GET_SCHUKO2, False, True),
             # "powGetSysGrid": -135.0,
-            WattsSensorEntity(client, self, "powGetSysGrid", const.STREAM_POWER_GRID),
+            StreamACWattsSensorEntity(client, self, "powGetSysGrid", const.STREAM_POWER_GRID),
             # "powGetSysLoad": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoad", const.STREAM_GET_SYS_LOAD),
+            StreamACWattsSensorEntity(client, self, "powGetSysLoad", const.STREAM_GET_SYS_LOAD),
             # "powGetSysLoadFromBp": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromBp", const.STREAM_GET_SYS_LOAD_FROM_BP),
+            StreamACWattsSensorEntity(client, self, "powGetSysLoadFromBp", const.STREAM_GET_SYS_LOAD_FROM_BP),
             # "powGetSysLoadFromGrid": 0.0,
-            WattsSensorEntity(
+            StreamACWattsSensorEntity(
                 client,
                 self,
                 "powGetSysLoadFromGrid",
                 const.STREAM_GET_SYS_LOAD_FROM_GRID,
             ),
             # "powGetSysLoadFromPv": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromPv", const.STREAM_GET_SYS_LOAD_FROM_PV),
+            StreamACWattsSensorEntity(client, self, "powGetSysLoadFromPv", const.STREAM_GET_SYS_LOAD_FROM_PV),
             # "powSysAcInMax": 4462,
             # "powSysAcOutMax": 800,
             # "productDetail": 5,
@@ -240,7 +271,7 @@ class StreamAC(BaseInternalDevice):
             # "stormPatternEndTime": 0,
             # "stormPatternOpenFlag": false,
             # "sysGridConnectionPower": -2020.0437,
-            WattsSensorEntity(client, self, "sysGridConnectionPower", const.STREAM_POWER_AC_SYS, False),
+            StreamACWattsSensorEntity(client, self, "sysGridConnectionPower", const.STREAM_POWER_AC_SYS, False),
             # "sysLoaderVer": 4294967295,
             # "sysState": 3,
             # "sysVer": 33620026,

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -6,11 +6,12 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import PERCENTAGE
 from homeassistant.util import utcnow
 
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import BaseInternalDevice, const
-from custom_components.ecoflow_cloud.number import BatteryBackupLevel
+from custom_components.ecoflow_cloud.number import BatteryBackupLevel, MinMaxLevelEntity
 from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     CumulativeCapacitySensorEntity,
@@ -327,6 +328,68 @@ class StreamAC(BaseInternalDevice):
         msg.msg.CopyFrom(header)
         return msg.SerializeToString()
 
+    def _build_proto_paired_command(
+        self,
+        field_num_a: int,
+        value_a: int,
+        field_num_b: int,
+        value_b: int,
+    ) -> bytes:
+        """Build a write that carries two varint fields in one pdata.
+
+        Some cfg writes on this device must include multiple paired fields
+        in a single message — e.g. the SOC limit pair cfgMaxChgSoc (33)
+        and cfgMinDsgSoc (34): writing only one of them is silently
+        rejected by the device. Captured from the EcoFlow mobile app
+        2026-05-26 — the app always emits both fields together even when
+        only one slider changed, and the device only honours the change
+        when both arrive in the same pdata.
+        """
+        import time
+        from .proto import stream_ac_pb2
+
+        def encode_varint(n):
+            result = bytearray()
+            while True:
+                bits = n & 0x7F
+                n >>= 7
+                if n:
+                    result.append(0x80 | bits)
+                else:
+                    result.append(bits)
+                    break
+            return bytes(result)
+
+        def encode_field(fnum, val):
+            return encode_varint((fnum << 3) | 0) + encode_varint(val)
+
+        pdata = (
+            encode_field(6, int(time.time()))
+            + encode_field(field_num_a, value_a)
+            + encode_field(field_num_b, value_b)
+        )
+
+        import random
+        header = stream_ac_pb2.StreamACHeader()
+        header.src = 32
+        header.dest = 2
+        header.d_src = 1
+        header.d_dest = 1
+        header.cmd_func = 254
+        header.cmd_id = 17
+        header.data_len = len(pdata)
+        header.need_ack = 1
+        header.seq = random.randint(100000000, 999999999)
+        header.product_id = 58
+        header.version = 3
+        header.payload_ver = 1
+        setattr(header, "from", "Android")
+        header.pdata = pdata
+
+        msg = stream_ac_pb2.StreamACSendHeaderMsg()
+        msg.msg.CopyFrom(header)
+        return msg.SerializeToString()
+
     def _build_proto_nested_command(
         self,
         outer_field_num: int,
@@ -408,6 +471,43 @@ class StreamAC(BaseInternalDevice):
                 raw = outer_self._build_proto_command(102, int(value))
                 client.mqtt_client.publish(outer_self.device_info.set_topic, raw)
 
+        class PairedSocNumberEntity(MinMaxLevelEntity):
+            """SOC limit number that always writes the paired companion too.
+
+            cfgMaxChgSoc (33) and cfgMinDsgSoc (34) must arrive in the same
+            pdata, otherwise the device silently rejects the write. Each
+            entity holds its own (mqtt_key, field_num) plus the companion's
+            field_num and the mqtt_key for its current value, looked up
+            from the device's last-known telemetry at write time.
+            """
+
+            _attr_native_unit_of_measurement = PERCENTAGE
+
+            def __init__(
+                self_,
+                *args,
+                my_field_num: int,
+                other_field_num: int,
+                other_mqtt_key: str,
+                other_fallback: int,
+                **kwargs,
+            ):
+                self_._my_field_num = my_field_num
+                self_._other_field_num = other_field_num
+                self_._other_mqtt_key = other_mqtt_key
+                self_._other_fallback = other_fallback
+                super().__init__(*args, **kwargs)
+
+            async def async_set_native_value(self_, value: float):
+                other_val = outer_self.data.params.get(
+                    self_._other_mqtt_key, self_._other_fallback
+                )
+                raw = outer_self._build_proto_paired_command(
+                    self_._my_field_num, int(value),
+                    self_._other_field_num, int(other_val),
+                )
+                client.mqtt_client.publish(outer_self.device_info.set_topic, raw)
+
         return [
             ProtoBackupReserveEntity(
                 client,
@@ -420,6 +520,23 @@ class StreamAC(BaseInternalDevice):
                 "cmsMaxChgSoc",
                 3,
                 lambda value: {},
+            ),
+            # Max charge SOC — write field 33 paired with field 34; read at
+            # field 270 (cmsMaxChgSoc). See _build_proto_paired_command for
+            # why the pairing is mandatory.
+            PairedSocNumberEntity(
+                client, self, "cmsMaxChgSoc", const.MAX_CHARGE_LEVEL,
+                50, 100, lambda value: {},
+                my_field_num=33, other_field_num=34,
+                other_mqtt_key="cmsMinDsgSoc", other_fallback=5,
+            ),
+            # Min discharge SOC — write field 34 paired with field 33; read
+            # at field 271 (cmsMinDsgSoc).
+            PairedSocNumberEntity(
+                client, self, "cmsMinDsgSoc", const.MIN_DISCHARGE_LEVEL,
+                0, 30, lambda value: {},
+                my_field_num=34, other_field_num=33,
+                other_mqtt_key="cmsMaxChgSoc", other_fallback=100,
             ),
         ]
 
@@ -504,6 +621,16 @@ class StreamAC(BaseInternalDevice):
                 lambda value: {}, field_num=380, enable_val=1, disable_val=0,
                 enableValue=True, disableValue=False,
             ),
+            # AC2 relay — write field 381 (adjacent to AC1's 380). Captured
+            # from the EcoFlow app 2026-05-26: toggling AC2 in the app emits
+            # a single-varint write at f381 with value 0/1, same encoding as
+            # AC1. The strategy doc's cfgAc2OutOpen=377 was incorrect for
+            # this device generation.
+            ProtoEnabledEntity(
+                client, self, "relay3Onoff", const.MODE_AC2_ON,
+                lambda value: {}, field_num=381, enable_val=1, disable_val=0,
+                enableValue=True, disableValue=False,
+            ),
             # Legacy Self-Powered-only switch, superseded by the four-option
             # Operating mode select below. Disabled by default for new installs
             # but kept so existing users' automations don't break on upgrade.
@@ -571,6 +698,14 @@ class StreamAC(BaseInternalDevice):
 
     _MANUAL_FIELD_MAP: dict = {
         6: ("f32ShowSoc", int),
+        # Read mirrors of cfgMaxChgSoc (write 33) and cfgMinDsgSoc (write 34).
+        # Empirically captured 2026-05-26 from a real device: moving the
+        # Min discharge SOC slider in the EcoFlow app from 12 → 16 caused
+        # f271 in the next DisplayPropertyUpload to flip from 12 → 16.
+        # Both writes echo through these read fields within one telemetry
+        # cycle. f730/f994 (the previous guesses) are unrelated.
+        270: ("cmsMaxChgSoc", int),
+        271: ("cmsMinDsgSoc", int),
         # See the field-380 note above ProtoEnabledEntity in switches(). This
         # entry is currently dead because incoming field 380 lives two levels
         # deep inside Champ_cmd21_3 (where the proto names it plugInInfoPvVol,

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -826,6 +826,18 @@ class StreamAC(BaseInternalDevice):
                 lambda value: {}, field_num=381, enable_val=1, disable_val=0,
                 enableValue=True, disableValue=False,
             ),
+            # "Semi-automated monitoring" discharge-strategy enable (field 239).
+            # Confirmed on hardware 2026-05-31 via this switch: enable_val=1
+            # starts discharge (battery 0 -> -800W to AC output, read field 1628
+            # 0->1->2); disable_val=2 stops it (1628 -> 0, battery -> 0). Note
+            # f239=0 was also acked but did NOT stop discharge, so the enum is
+            # 1=on / 2=off (same as feedGridMode field 168), not 1/0. This
+            # switch's shown state is optimistic (no dedicated read field).
+            ProtoEnabledEntity(
+                client, self, "dischargeStrategy239", const.STREAM_SEMI_AUTO_DISCHARGE,
+                lambda value: {}, field_num=239, enable_val=1, disable_val=2,
+                enableValue=True, disableValue=False,
+            ),
             # Schedule enable/disable. Class definition is above; this
             # instance re-emits the active SetTimeTask entry with the new
             # isEnable bit, preserving the other params from telemetry.

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -629,6 +629,14 @@ class StreamAC(BaseInternalDevice):
                 raw = outer_self._build_proto_command(102, int(value))
                 client.mqtt_client.publish(outer_self.device_info.set_topic, raw)
 
+            def _updated(self_, data):
+                super()._updated(data)
+                # Pin to a fixed 15-100 range (true hardware ceiling) rather than
+                # BatteryBackupLevel's dynamic clamp to the SOC limits, which capped
+                # max at cmsMaxChgSoc (e.g. 82). Lets 95 be set as a charge target.
+                self_._attr_native_min_value = 15
+                self_._attr_native_max_value = 100
+
         class PairedSocNumberEntity(MinMaxLevelEntity):
             """SOC limit number that always writes the paired companion too.
 
@@ -672,8 +680,8 @@ class StreamAC(BaseInternalDevice):
                 self,
                 "backupReverseSoc",
                 const.BACKUP_RESERVE_LEVEL,
-                3,
-                95,
+                15,
+                100,
                 "cmsMinDsgSoc",
                 "cmsMaxChgSoc",
                 3,

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -20,6 +20,7 @@ from custom_components.ecoflow_cloud.sensor import (
     InWattsSensorEntity,
     LevelSensorEntity,
     MilliVoltSensorEntity,
+    MiscSensorEntity,
     OutWattsSensorEntity,
     RemainSensorEntity,
     TempSensorEntity,
@@ -283,6 +284,19 @@ class StreamAC(BaseInternalDevice):
             .attr("minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             # "waterInFlag": 0,
+            # Schedule entry — _decode_schedule_entry surfaces the active
+            # SetTimeTaskWrite-style entry from DisplayPropertyUpload field
+            # 584 into raw["params"]["schedule.*"]. The summary string is
+            # the entity state; the structured fields hang off as attrs.
+            MiscSensorEntity(client, self, "schedule.summary", const.STREAM_SCHEDULE)
+            .attr("schedule.enabled", "Enabled", False)
+            .attr("schedule.power", "Power (W)", 0)
+            .attr("schedule.startMin", "Start (min of day)", 0)
+            .attr("schedule.endMin", "End (min of day)", 0)
+            .attr("schedule.days", "Days bitmask", 0)
+            .attr("schedule.timeMode", "Time mode", 0)
+            .attr("schedule.taskIndex", "Task index", 0)
+            .attr("schedule.isValid", "Is valid", False),
         ]
 
     def _build_proto_command(self, field_num: int, value: int) -> bytes:
@@ -306,6 +320,119 @@ class StreamAC(BaseInternalDevice):
             return encode_varint((fnum << 3) | 0) + encode_varint(val)
 
         pdata = encode_field(6, int(time.time())) + encode_field(field_num, value)
+
+        import random
+        header = stream_ac_pb2.StreamACHeader()
+        header.src = 32
+        header.dest = 2
+        header.d_src = 1
+        header.d_dest = 1
+        header.cmd_func = 254
+        header.cmd_id = 17
+        header.data_len = len(pdata)
+        header.need_ack = 1
+        header.seq = random.randint(100000000, 999999999)
+        header.product_id = 58
+        header.version = 3
+        header.payload_ver = 1
+        setattr(header, "from", "Android")
+        header.pdata = pdata
+
+        msg = stream_ac_pb2.StreamACSendHeaderMsg()
+        msg.msg.CopyFrom(header)
+        return msg.SerializeToString()
+
+    def _build_proto_schedule_command(
+        self,
+        *,
+        task_index: int,
+        enabled: bool,
+        is_valid: bool,
+        is_repeating: bool,
+        time_mode: int,
+        days: int,
+        start_min: int,
+        end_min: int,
+        power: int,
+    ) -> bytes:
+        """Build a `SetTimeTaskWrite`-shaped write at outer field 595.
+
+        Empirical field semantics (capture session 2026-05-26):
+            inner f2  = taskIndex (slot number, observed=2)
+            inner f3  = isValid (always 1 in valid entries)
+            inner f4  = isEnable (elided when 0)
+            inner f5  = isRepeating
+            inner f8  = timeMode (1=daily, 2=weekly; device-specific enum)
+            inner f9  = days bitmask (bit0=Mon … bit6=Sun; only meaningful
+                        when time_mode >= 2)
+            inner f10 = timeTable — packed varint with
+                        `(end_min << 16) | start_min`
+            inner f12 = power in watts
+
+        Inner fields f6, f7, f11 are not used by this device generation
+        despite the decompiled-proto's SetTimeTaskWrite schema listing
+        them. The strategy doc's enum/field-mapping for the schedule was
+        wrong for this device; mappings above are the live truth.
+
+        There is no `type` (AC1 / AC2 / grid) field in the schedule
+        entry — discharge routing is controlled by feedGridMode
+        (field 168) at the device level, not per-schedule.
+        """
+        import time
+        from .proto import stream_ac_pb2
+
+        def encode_varint(n):
+            result = bytearray()
+            while True:
+                bits = n & 0x7F
+                n >>= 7
+                if n:
+                    result.append(0x80 | bits)
+                else:
+                    result.append(bits)
+                    break
+            return bytes(result)
+
+        def encode_field(fnum, val):
+            return encode_varint((fnum << 3) | 0) + encode_varint(val)
+
+        def encode_bytes_field(fnum, payload):
+            return (
+                encode_varint((fnum << 3) | 2)
+                + encode_varint(len(payload))
+                + payload
+            )
+
+        # Build the inner SetTimeTaskWrite body. Field order and presence
+        # match the EcoFlow app's captured wire layout exactly: f3 and f5
+        # are always emitted (even when their value is 0 — proto3 would
+        # normally elide that, but the device may rely on the explicit
+        # presence, similar to how the cfgMaxChgSoc/cfgMinDsgSoc pair is
+        # silently rejected when only one field is sent). f4 is the one
+        # field the app does drop on disable — captured behavior.
+        inner_parts = [
+            encode_field(2, task_index),
+            encode_field(3, 1 if is_valid else 0),
+        ]
+        if enabled:
+            inner_parts.append(encode_field(4, 1))
+        inner_parts.append(encode_field(5, 1 if is_repeating else 0))
+        inner_parts.append(encode_field(8, time_mode))
+        inner_parts.append(encode_field(9, days))
+        time_table_value = ((end_min & 0xFFFF) << 16) | (start_min & 0xFFFF)
+        inner_parts.append(encode_bytes_field(10, encode_varint(time_table_value)))
+        inner_parts.append(encode_field(12, power))
+        inner = b"".join(inner_parts)
+
+        # The schedule field 595 wraps an inner field-1 sub-message
+        # containing the actual SetTimeTaskWrite. If the device supported
+        # multiple entries in one write, additional field-1 sub-messages
+        # would appear here.
+        wrapper = encode_bytes_field(1, inner)
+        pdata = (
+            encode_field(6, int(time.time()))
+            + encode_bytes_field(595, wrapper)
+        )
 
         import random
         header = stream_ac_pb2.StreamACHeader()
@@ -542,6 +669,43 @@ class StreamAC(BaseInternalDevice):
 
     def switches(self, client: EcoflowApiClient) -> list[SwitchEntity]:
         from custom_components.ecoflow_cloud.switch import EnabledEntity
+        outer_self = self
+
+        class ScheduleEnabledSwitchEntity(EnabledEntity):
+            """Toggle the active schedule entry on/off by re-sending the
+            full SetTimeTaskWrite at field 595 with the new isEnable bit.
+
+            All other parameters (taskIndex, time slot, power, days,
+            timeMode, isValid, isRepeating) are read from the last-known
+            telemetry surfaced by _decode_schedule_entry; this entity does
+            not let the user edit them — use the EcoFlow mobile app for
+            that and then gate the resulting schedule on/off from here.
+            """
+
+            def turn_on(self_, **kwargs):
+                self_._send_schedule(True)
+                self_._attr_is_on = True
+                self_.schedule_update_ha_state()
+
+            def turn_off(self_, **kwargs):
+                self_._send_schedule(False)
+                self_._attr_is_on = False
+                self_.schedule_update_ha_state()
+
+            def _send_schedule(self_, enabled: bool):
+                params = outer_self.data.params
+                raw = outer_self._build_proto_schedule_command(
+                    task_index=int(params.get("schedule.taskIndex") or 2),
+                    enabled=enabled,
+                    is_valid=bool(params.get("schedule.isValid", True)),
+                    is_repeating=bool(params.get("schedule.isRepeating", False)),
+                    time_mode=int(params.get("schedule.timeMode") or 1),
+                    days=int(params.get("schedule.days") or 0),
+                    start_min=int(params.get("schedule.startMin") or 0),
+                    end_min=int(params.get("schedule.endMin") or 0),
+                    power=int(params.get("schedule.power") or 0),
+                )
+                client.mqtt_client.publish(outer_self.device_info.set_topic, raw)
 
         class ProtoEnabledEntity(EnabledEntity):
             def __init__(self_, *args, field_num, enable_val, disable_val, **kwargs):
@@ -629,6 +793,16 @@ class StreamAC(BaseInternalDevice):
             ProtoEnabledEntity(
                 client, self, "relay3Onoff", const.MODE_AC2_ON,
                 lambda value: {}, field_num=381, enable_val=1, disable_val=0,
+                enableValue=True, disableValue=False,
+            ),
+            # Schedule enable/disable. Class definition is above; this
+            # instance re-emits the active SetTimeTask entry with the new
+            # isEnable bit, preserving the other params from telemetry.
+            ScheduleEnabledSwitchEntity(
+                client, self,
+                "schedule.enabled",
+                const.STREAM_SCHEDULE_ENABLED,
+                lambda value: {},
                 enableValue=True, disableValue=False,
             ),
             # Legacy Self-Powered-only switch, superseded by the four-option
@@ -736,6 +910,114 @@ class StreamAC(BaseInternalDevice):
         },
     }
 
+    # Day bitmask labels in human order, bit0=Mon (per inner field 9 of the
+    # schedule entry — see _build_proto_schedule_command). Used to render the
+    # `schedule.days` raw int into a friendly summary.
+    _SCHEDULE_DAY_LABELS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+    def _decode_schedule_entry(self, wrapper_bytes: bytes, raw: dict) -> None:
+        """Decode the schedule entry at top-level field 584 (read mirror of
+        the write at field 595). See _build_proto_schedule_command for the
+        inner field mapping; this is the inverse.
+
+        Surfaces the decoded values into ``raw["params"]`` under
+        ``schedule.*`` keys so they can be bound to sensor attributes and
+        re-used by the schedule_enabled switch when it re-sends the entry
+        with one flag flipped.
+        """
+
+        def varint(b, p):
+            r, s = 0, 0
+            while p < len(b):
+                x = b[p]; p += 1
+                r |= (x & 0x7f) << s
+                if not (x & 0x80): return r, p
+                s += 7
+            return r, p
+
+        # Outer wrapper: a single field-1 sub-message holding the entry.
+        try:
+            p = 0
+            tag, p = varint(wrapper_bytes, p)
+            if (tag >> 3) != 1 or (tag & 7) != 2:
+                return
+            ln, p = varint(wrapper_bytes, p)
+            inner = wrapper_bytes[p:p + ln]
+        except Exception:
+            return
+
+        # Defaults reflect "no schedule configured" — proto3 elides
+        # zero-value scalars on the wire, so any missing field implies 0.
+        entry = {
+            "taskIndex": 0,
+            "isValid": False,
+            "enabled": False,
+            "isRepeating": False,
+            "timeMode": 0,
+            "days": 0,
+            "startMin": 0,
+            "endMin": 0,
+            "power": 0,
+        }
+        p = 0
+        while p < len(inner):
+            try:
+                tag, p = varint(inner, p)
+            except Exception:
+                break
+            fn, wt = tag >> 3, tag & 7
+            if wt == 0:
+                v, p = varint(inner, p)
+                if fn == 2: entry["taskIndex"] = v
+                elif fn == 3: entry["isValid"] = bool(v)
+                elif fn == 4: entry["enabled"] = bool(v)
+                elif fn == 5: entry["isRepeating"] = bool(v)
+                elif fn == 8: entry["timeMode"] = v
+                elif fn == 9: entry["days"] = v
+                elif fn == 12: entry["power"] = v
+            elif wt == 2:
+                sub_ln, p = varint(inner, p)
+                val_bytes = inner[p:p + sub_ln]
+                p += sub_ln
+                if fn == 10 and val_bytes:
+                    # timeTable is a `repeated uint32 packed` carrying one
+                    # entry here: (end_min << 16) | start_min, varint-encoded.
+                    try:
+                        tt, _ = varint(val_bytes, 0)
+                        entry["startMin"] = tt & 0xFFFF
+                        entry["endMin"] = tt >> 16
+                    except Exception:
+                        pass
+            else:
+                break
+
+        # Surface every field individually for the entity attribute view.
+        for k, v in entry.items():
+            raw["params"][f"schedule.{k}"] = v
+
+        # Rendered one-line summary used as the sensor state. Examples:
+        #   "disabled"
+        #   "Mon|Wed|Fri 10:00-12:00 400W"
+        #   "daily 08:00-20:00 600W"
+        if not entry["isValid"]:
+            summary = "invalid"
+        elif not entry["enabled"]:
+            summary = "disabled"
+        else:
+            start = entry["startMin"]
+            end = entry["endMin"]
+            time_str = f"{start//60:02d}:{start%60:02d}-{end//60:02d}:{end%60:02d}"
+            if entry["timeMode"] >= 2 and entry["days"]:
+                days_str = "|".join(
+                    label
+                    for bit, label in enumerate(self._SCHEDULE_DAY_LABELS)
+                    if entry["days"] & (1 << bit)
+                )
+            else:
+                days_str = "daily"
+            summary = f"{days_str} {time_str} {entry['power']}W"
+        raw["params"]["schedule.summary"] = summary
+
     def _decode_manual_fields(self, pdata: bytes, raw: dict) -> None:
         """Extract specific unmapped protobuf varint fields from raw pdata bytes."""
 
@@ -804,6 +1086,10 @@ class StreamAC(BaseInternalDevice):
                                     break
                             except Exception:
                                 break
+                    elif field_num == 584:
+                        # Schedule entry (read mirror of write field 595).
+                        # Empirically mapped — see _decode_schedule_entry.
+                        self._decode_schedule_entry(sub_bytes, raw)
                     elif field_num not in self._MANUAL_FIELD_MAP:
                         _LOGGER.info(
                             "STREAM_AC_BOOL_GROUP field=%d len=%d hex=%s",

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -385,6 +385,7 @@ class StreamAC(BaseInternalDevice):
         return []
 
     _MANUAL_FIELD_MAP: dict = {
+        6: ("f32ShowSoc", int),
         380: ("relay2Onoff", bool),
         461: ("backupReverseSoc", int),
         1628: ("feedGridMode", int),

--- a/custom_components/ecoflow_cloud/services.yaml
+++ b/custom_components/ecoflow_cloud/services.yaml
@@ -1,0 +1,104 @@
+stream_ac_set_schedule:
+  name: Stream AC Pro — set schedule
+  description: >-
+    Write a single schedule entry (SetTimeTaskWrite) to a Stream AC Pro. All
+    fields are required; the entry is encoded and published to the device's
+    set topic over MQTT. See docs/stream_ac_proto_fields.md for the wire format.
+  fields:
+    serial:
+      name: Serial number
+      description: Serial number of the target Stream AC Pro device.
+      required: true
+      example: BKxxxxxxxxxxxxxx
+      selector:
+        text:
+    task_index:
+      name: Task index
+      description: Schedule slot number to write (inner field 2; slot 2 observed in captures).
+      required: true
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 1
+          mode: box
+    enabled:
+      name: Enabled
+      description: Whether the schedule entry is active (inner field isEnable).
+      required: true
+      example: true
+      selector:
+        boolean:
+    is_valid:
+      name: Is valid
+      description: Marks the entry as a valid slot (inner field isValid; set true for real entries).
+      required: true
+      example: true
+      selector:
+        boolean:
+    is_repeating:
+      name: Is repeating
+      description: Whether the entry repeats rather than running once (inner field isRepeating).
+      required: true
+      example: false
+      selector:
+        boolean:
+    time_mode:
+      name: Time mode
+      description: Recurrence mode (inner field 8). 1 = daily, 2 = weekly (uses the days bitmask).
+      required: true
+      example: 2
+      selector:
+        number:
+          min: 1
+          max: 2
+          step: 1
+          mode: box
+    days:
+      name: Days bitmask
+      description: >-
+        Weekday bitmask (inner field 9): bit0 = Monday … bit6 = Sunday
+        (0–127). Only meaningful when time_mode is 2 (weekly).
+      required: true
+      example: 31
+      selector:
+        number:
+          min: 0
+          max: 127
+          step: 1
+          mode: box
+    start_min:
+      name: Start (minute of day)
+      description: Schedule start as minutes since midnight (0–1439). E.g. 480 = 08:00.
+      required: true
+      example: 480
+      selector:
+        number:
+          min: 0
+          max: 1439
+          step: 1
+          mode: box
+    end_min:
+      name: End (minute of day)
+      description: Schedule end as minutes since midnight (0–1439). E.g. 1320 = 22:00.
+      required: true
+      example: 1320
+      selector:
+        number:
+          min: 0
+          max: 1439
+          step: 1
+          mode: box
+    power:
+      name: Power
+      description: Target power for the schedule entry, in watts (inner field 12).
+      required: true
+      example: 600
+      selector:
+        number:
+          min: 0
+          max: 800
+          step: 1
+          unit_of_measurement: W
+          mode: box

--- a/docs/stream_ac_proto_fields.md
+++ b/docs/stream_ac_proto_fields.md
@@ -1,0 +1,194 @@
+# Stream AC Pro protobuf field reference
+
+This document tracks the protobuf field numbers used by the Stream AC Pro
+(`product_id=58`, internal type `STREAM_AC`, EcoFlow codename **PD335**) and
+their verification status against real hardware. Field numbers in this
+device's protocol are direction-specific — a number that means one thing in
+a write may mean something completely different in a read — so each is
+tracked separately.
+
+## How to read this
+
+- **Status = ✅ verified**: round-tripped against a real device. Writes
+  produce a `cmd_id=18, is_ack=1` reply *and* the new value is reflected in
+  subsequent telemetry. Reads consistently surface the expected value.
+- **Status = ⚠️ unverified**: the field number comes from a decompiled APK
+  proto or an external reference. Behavior on real hardware is unknown.
+- **Status = ❌ rejected**: the field number was tested and the device
+  either silently ignored it (no ack) or acked without applying the value.
+
+## Important: write fields must be empirically verified
+
+> **The APK-decompiled `Pd335Sys.ConfigWrite` proto is *not* a reliable
+> source of truth for this device's accepted write field numbers.**
+> Read-side structure (DisplayPropertyUpload field layout) from the decompile
+> appears reliable, but several write field numbers from `ConfigWrite` that
+> the strategy doc enumerated do not work on this device:
+>
+> - Fields **33, 34** (`cfgMaxChgSoc`, `cfgMinDsgSoc`): the device acks with
+>   `is_ack=1` but the value never updates in subsequent telemetry. Net:
+>   silently ignored.
+> - Fields **18, 19, 76, 377** (`cfgDc12VOutOpen`, `cfgUsbOpen`,
+>   `cfgAcOutOpen`, `cfgAc2OutOpen`): the device does not ack at all. Net:
+>   message dropped entirely.
+>
+> Possible explanations: the APK we decompiled targeted a different PD335
+> variant or firmware version; this device's ConfigWrite uses a different
+> field-numbering scheme; or these settings are configured through a
+> different message id / command class entirely.
+>
+> **Treat every "new" write field as unverified until a capture session has
+> shown the device both acks the write and echoes the new value in a
+> subsequent telemetry frame.** See the capture-session guide at the end
+> of this document.
+
+## Verified write fields (use these with confidence)
+
+| Write field | Wire shape | Purpose | Read mirror | Source |
+|---:|---|---|---|---|
+| 102 | top-level varint (0–95 typical) | `cfgBackupReverseSoc` — backup reserve SOC % | field 461 (`backupReverseSoc`) | commit `de63679` |
+| 106 | nested sub-message; inner field 1/2/3/4 = 1; trailing empty field 546 commit marker | `cfgEnergyStrategyOperateMode` — operating-mode radio group (Self-Powered / Scheduled / TOU / Smart) | field 393 (matching inner field = 1) | commit `8b2c88c`, `ec524fb` |
+| 168 | top-level varint (1 or 2) | `feedGridMode` — feed-in control on/off | field 1628 | commit `218ad96` |
+| 380 | top-level varint (0 or 1) | `relay2Onoff` — AC1 relay click | not surfaced yet (field 380 in DisplayPropertyUpload is `plugInInfoPvVol`, an unrelated float — see the note in `stream_ac.py` `switches()`) | commit `218ad96` |
+
+All four work via the existing `_build_proto_command` (or
+`_build_proto_nested_command` for field 106) in
+`custom_components/ecoflow_cloud/devices/internal/stream_ac.py`, using
+`cmd_func=254, cmd_id=17`. The device acks within ~200–600 ms with
+`cmd_func=254, cmd_id=18, is_ack=1` on the matching `seq`.
+
+## Verified read fields (DisplayPropertyUpload)
+
+These come through periodic `cmd_id=21` telemetry frames. Some appear in
+small incremental uploads (every ~2 s), some only in larger frames (~2 min
+cadence on this device, ~1020 bytes of pdata, starts with `9801...`).
+
+| Read field | Type | Param name in `raw["params"]` | Notes |
+|---:|---|---|---|
+| 6 | varint | `f32ShowSoc` (integer percent) | top-level; surfaced by `_MANUAL_FIELD_MAP[6]` |
+| 461 | varint | `backupReverseSoc` | top-level; surfaced by `_MANUAL_FIELD_MAP[461]` |
+| 393 | wire-type-2 sub-message; inner field 1/2/3/4 = 1 indicates active mode | `energyStrategyOperateMode.activeMode` + four `energyStrategyOperateMode.operate*Open` flags | surfaced by `_RADIO_GROUP_MAP[393]` |
+| 1628 | varint | `feedGridMode` | top-level; surfaced by `_MANUAL_FIELD_MAP[1628]` |
+| 730 | varint | (candidate `cmsMinDsgSoc`; value matches device's min discharge SOC setting but not currently mapped) | top-level — passive observation only; no write currently routes here |
+| 994 | varint | (candidate `cmsMaxChgSoc`; value matches device's max charge SOC setting but not currently mapped) | top-level — passive observation only; no write currently routes here |
+
+Fields 730 and 994 are read candidates only — see the failed-write notes
+above. Surfacing them as sensors would be safe; surfacing them as the
+read side of a writable number entity would mislead users until the
+matching write fields are identified.
+
+## Failed write attempts
+
+Recorded here so we don't burn time re-testing them with the same
+approach. Each was tested with `cmd_func=254, cmd_id=17` and the value
+encoded as a top-level varint (the same shape that works for fields 102,
+168, 380).
+
+| Tried | Intended setting | Failure mode | Tested |
+|---:|---|---|---|
+| 33 | `cfgMaxChgSoc` | acked (`is_ack=1`), value never applied (f994 unchanged) | session 2026-05-26 |
+| 34 | `cfgMinDsgSoc` | acked, never applied (f730 unchanged) | session 2026-05-26 |
+| 18 | `cfgDc12VOutOpen` | no ack, message dropped | session 2026-05-26 |
+| 19 | `cfgUsbOpen` | no ack, message dropped | session 2026-05-26 |
+| 76 | `cfgAcOutOpen` | no ack, message dropped | session 2026-05-26 |
+| 377 | `cfgAc2OutOpen` | no ack, message dropped | session 2026-05-26 |
+
+Implications by analogy: the strategy doc's other low-numbered
+ConfigWrite fields (`cfgAcStandbyTime=10`, `cfgDcStandbyTime=11`,
+`cfgScreenOffTime=12`, `cfgDevStandbyTime=13`, `cfgLcdLight=14`, etc.)
+are likely also wrong as written. Do not implement entities for these
+without first capturing the real write traffic.
+
+## Capture session: identifying a write field empirically
+
+The HA integration's MQTT client is subscribed to both
+`/app/{appId}/{serial}/thing/property/set` (writes) and `/set_reply`
+(acks). This means *every* write to the device — including writes sent
+by the EcoFlow mobile app, the device's own UI sync, etc. — passes
+through HA's view and is decoded by `_prepare_data`.
+
+To identify the write field for a setting `X`:
+
+1. Bump `custom_components.ecoflow_cloud` to `debug` level. Either edit
+   `configuration.yaml` and restart, or call the `logger.set_level`
+   service: `{"custom_components.ecoflow_cloud": "debug"}`.
+2. Have the device powered up, MQTT-connected (`Status` sensor =
+   `online` in HA), and physically observable.
+3. In the EcoFlow mobile app, change setting `X` **and nothing else**.
+   Note the wall-clock time of the change.
+4. In HA log, find the lines within ~2 seconds of that timestamp:
+   - A `DEBUG ... cmd id "17" fct id "254"` outgoing log entry shows
+     up first — that's the write traveling through the broker.
+   - The `payload` debug log just below contains the hex of the
+     header. The `new payload` line shows the pdata bytes after the
+     header was stripped.
+   - A `cmd id "18" ... is_ack: 1` log entry within ~500 ms confirms
+     the device accepted the write.
+   - A subsequent `STREAM_AC_BOOL_GROUP field=N len=M hex=...` (or, if
+     the field number is in `_MANUAL_FIELD_MAP`, a `Found N fields`
+     followed by a state change on a HA entity) shows what the write
+     contained.
+5. Decode the pdata bytes manually to extract the (field, value) pair.
+   Typical pattern: `08 <timestamp varint>` (field 6 = timestamp)
+   followed by `<tag> <value>` where the tag encodes the target field
+   number and wire type.
+
+   A minimal Python decoder:
+
+   ```python
+   def varint(b, p):
+       r, s = 0, 0
+       while p < len(b):
+           x = b[p]; p += 1
+           r |= (x & 0x7f) << s
+           if not (x & 0x80): return r, p
+           s += 7
+       return r, p
+
+   data = bytes.fromhex("PASTE pdata HEX HERE")
+   p = 0
+   while p < len(data):
+       tag, p = varint(data, p)
+       fn, wt = tag >> 3, tag & 7
+       if wt == 0:
+           v, p = varint(data, p)
+           print(f"field {fn}: varint = {v}")
+       elif wt == 2:
+           ln, p = varint(data, p)
+           print(f"field {fn}: bytes[{ln}] = {data[p:p+ln].hex()}")
+           p += ln
+       else:
+           break
+   ```
+
+6. Repeat the change in the EcoFlow app with the opposite value
+   (toggle off, toggle on, etc.) to confirm the same field number
+   carries a different value and identify the on/off encoding.
+7. Verify the read side: leave the app's change in place, watch for
+   the next telemetry frame (`cmd id "21"` with a large `new payload`
+   starting with `9801...`), and find the field whose value changes
+   between the pre-toggle and post-toggle captures. That's the read
+   mirror.
+
+The captured (write field, read field, on/off values) triple is then
+enough to add a switch via `ProtoEnabledEntity` and an entry to
+`_MANUAL_FIELD_MAP`.
+
+## Capture-session priorities
+
+When the next session happens, the highest-value targets to capture are:
+
+1. **AC1 output**, **AC2 output**, **USB**, **DC 12V** — Phase F switches
+   that are currently broken. Toggle each in the app, one at a time, both
+   directions.
+2. **Max charge SOC**, **min discharge SOC** — the SOC limit slider pair.
+   Move the slider in the app from a known value to a clearly distinct
+   value (e.g. max from 100 → 80; min from 5 → 15) and capture the write.
+3. **Standby times** (AC, DC, screen, device, AC2) — change each timer in
+   the app to a non-default value and capture.
+4. **Beep**, **LCD brightness** — easy quality-of-life toggles in the app
+   that share the same write infrastructure.
+
+Each of these costs roughly one app interaction + one log capture. A
+focused 15-minute session at home should be enough to resolve all of
+Phases F + G.

--- a/docs/stream_ac_proto_fields.md
+++ b/docs/stream_ac_proto_fields.md
@@ -97,11 +97,31 @@ outer pdata
       │                            normally permit explicit-0)
       ├─ inner-inner f5  varint  = isRepeating (always emitted on wire
       │                            — explicit 0 captured)
-      ├─ inner-inner f8  varint  = timeMode (1 = daily, 2 = weekly;
-      │                            device-specific enum that does NOT
-      │                            match the strategy doc's PD335 enum)
-      ├─ inner-inner f9  varint  = days bitmask, bit0=Mon … bit6=Sun;
-      │                            only meaningful when timeMode ≥ 2
+      ├─ inner-inner f8  varint  = timeMode
+      │                            * 1 = daily (every day; f9 = 0)
+      │                            * 2 = weekly (specific weekdays; f9
+      │                                  carries a bitmask, see below)
+      │                            Device-specific enum that does NOT
+      │                            match the strategy doc's PD335 enum.
+      ├─ inner-inner f9  varint  = days bitmask (only meaningful when
+      │                            timeMode = 2). 7 bits encoding the
+      │                            selected weekdays.
+      │                            **Bit-to-weekday convention is
+      │                            currently uncertain on this device.**
+      │                            The strategy doc claimed bit0=Mon
+      │                            with weekdays=31, weekends=96. An
+      │                            empirical observation during the
+      │                            2026-05-26 verification session
+      │                            saw a "MWF" schedule (per the user
+      │                            picking Mon/Wed/Fri checkboxes in the
+      │                            EcoFlow app, bitmask = 21 = 0b0010101)
+      │                            firing on a Tuesday during its time
+      │                            window. Under bit0=Mon, that bitmask
+      │                            shouldn't include Tuesday; under
+      │                            bit0=Sun it would (Sun|Tue|Thu = 21).
+      │                            Resolve with a targeted capture
+      │                            ("Sunday only" / "Saturday only" in
+      │                            the app, check the bitmask).
       ├─ inner-inner f10 bytes[4] = timeTable — a single varint inside
       │                            the length-delimited field, encoding
       │                            `(endMinute << 16) | startMinute`

--- a/docs/stream_ac_proto_fields.md
+++ b/docs/stream_ac_proto_fields.md
@@ -46,16 +46,30 @@ tracked separately.
 
 | Write field | Wire shape | Purpose | Read mirror | Source |
 |---:|---|---|---|---|
+| 33 (paired w/ 34) | two top-level varints in one pdata: `cfgMaxChgSoc` + `cfgMinDsgSoc` | `cfgMaxChgSoc` — max charge SOC % (50–100) | field 270 (`cmsMaxChgSoc`) | capture 2026-05-26 |
+| 34 (paired w/ 33) | as above — always send both fields together, never alone | `cfgMinDsgSoc` — min discharge SOC % (0–30) | field 271 (`cmsMinDsgSoc`) | capture 2026-05-26 |
 | 102 | top-level varint (0–95 typical) | `cfgBackupReverseSoc` — backup reserve SOC % | field 461 (`backupReverseSoc`) | commit `de63679` |
 | 106 | nested sub-message; inner field 1/2/3/4 = 1; trailing empty field 546 commit marker | `cfgEnergyStrategyOperateMode` — operating-mode radio group (Self-Powered / Scheduled / TOU / Smart) | field 393 (matching inner field = 1) | commit `8b2c88c`, `ec524fb` |
 | 168 | top-level varint (1 or 2) | `feedGridMode` — feed-in control on/off | field 1628 | commit `218ad96` |
 | 380 | top-level varint (0 or 1) | `relay2Onoff` — AC1 relay click | not surfaced yet (field 380 in DisplayPropertyUpload is `plugInInfoPvVol`, an unrelated float — see the note in `stream_ac.py` `switches()`) | commit `218ad96` |
+| 381 | top-level varint (0 or 1) | `relay3Onoff` — AC2 relay (the strategy doc's `cfgAc2OutOpen=377` was wrong) | not surfaced yet | capture 2026-05-26 |
 
-All four work via the existing `_build_proto_command` (or
-`_build_proto_nested_command` for field 106) in
+All work via the existing `_build_proto_command` (single varint),
+`_build_proto_paired_command` (paired varints, for the SOC pair), or
+`_build_proto_nested_command` (sub-message, for field 106) in
 `custom_components/ecoflow_cloud/devices/internal/stream_ac.py`, using
 `cmd_func=254, cmd_id=17`. The device acks within ~200–600 ms with
 `cmd_func=254, cmd_id=18, is_ack=1` on the matching `seq`.
+
+### Paired-write requirement (important)
+
+The SOC pair `cfgMaxChgSoc` + `cfgMinDsgSoc` must be sent **together** in
+the same pdata. Sending one alone produces an `is_ack=1` reply but the
+device silently does not apply the change — the trap that originally
+made Phase C look broken. Captured from the EcoFlow app: it always
+emits both fields together even when only one slider moved. There may
+be other paired-field groups in this device's ConfigWrite vocabulary;
+treat partial-config writes as suspect until verified.
 
 ## Verified read fields (DisplayPropertyUpload)
 
@@ -66,38 +80,44 @@ cadence on this device, ~1020 bytes of pdata, starts with `9801...`).
 | Read field | Type | Param name in `raw["params"]` | Notes |
 |---:|---|---|---|
 | 6 | varint | `f32ShowSoc` (integer percent) | top-level; surfaced by `_MANUAL_FIELD_MAP[6]` |
+| 270 | varint | `cmsMaxChgSoc` | top-level; surfaced by `_MANUAL_FIELD_MAP[270]`. Mirror of `cfgMaxChgSoc` (write field 33). |
+| 271 | varint | `cmsMinDsgSoc` | top-level; surfaced by `_MANUAL_FIELD_MAP[271]`. Mirror of `cfgMinDsgSoc` (write field 34). |
 | 461 | varint | `backupReverseSoc` | top-level; surfaced by `_MANUAL_FIELD_MAP[461]` |
 | 393 | wire-type-2 sub-message; inner field 1/2/3/4 = 1 indicates active mode | `energyStrategyOperateMode.activeMode` + four `energyStrategyOperateMode.operate*Open` flags | surfaced by `_RADIO_GROUP_MAP[393]` |
 | 1628 | varint | `feedGridMode` | top-level; surfaced by `_MANUAL_FIELD_MAP[1628]` |
-| 730 | varint | (candidate `cmsMinDsgSoc`; value matches device's min discharge SOC setting but not currently mapped) | top-level — passive observation only; no write currently routes here |
-| 994 | varint | (candidate `cmsMaxChgSoc`; value matches device's max charge SOC setting but not currently mapped) | top-level — passive observation only; no write currently routes here |
 
-Fields 730 and 994 are read candidates only — see the failed-write notes
-above. Surfacing them as sensors would be safe; surfacing them as the
-read side of a writable number entity would mislead users until the
-matching write fields are identified.
+Fields **730 and 994** were earlier guessed to be the SOC read mirrors
+because their values happened to match (5, 100) at the time of capture.
+Empirical verification later (2026-05-26 capture: moving the Min
+discharge slider from 12 → 16 caused `f271` to track 12 → 16 while
+`f730` stayed at 5) proved 730/994 are unrelated. They may be storm-mode
+SOC, TOU SOC, or BMS absolute limits — currently unmapped.
 
-## Failed write attempts
+## Failed write attempts and what we learned
 
 Recorded here so we don't burn time re-testing them with the same
 approach. Each was tested with `cmd_func=254, cmd_id=17` and the value
-encoded as a top-level varint (the same shape that works for fields 102,
-168, 380).
+encoded as a top-level varint (the same shape that works for the
+verified single-field writes 102 / 168 / 380 / 381).
 
-| Tried | Intended setting | Failure mode | Tested |
+| Tried | Intended setting | Failure mode | Resolution |
 |---:|---|---|---|
-| 33 | `cfgMaxChgSoc` | acked (`is_ack=1`), value never applied (f994 unchanged) | session 2026-05-26 |
-| 34 | `cfgMinDsgSoc` | acked, never applied (f730 unchanged) | session 2026-05-26 |
-| 18 | `cfgDc12VOutOpen` | no ack, message dropped | session 2026-05-26 |
-| 19 | `cfgUsbOpen` | no ack, message dropped | session 2026-05-26 |
-| 76 | `cfgAcOutOpen` | no ack, message dropped | session 2026-05-26 |
-| 377 | `cfgAc2OutOpen` | no ack, message dropped | session 2026-05-26 |
+| 33 alone | `cfgMaxChgSoc` | acked, value never applied | works when **paired** with f34 — see Verified table above |
+| 34 alone | `cfgMinDsgSoc` | acked, never applied | works when **paired** with f33 |
+| 18 | `cfgDc12VOutOpen` | no ack, dropped | this device has no DC 12V output — the EcoFlow app doesn't expose the toggle either. Strategy-doc field number may be valid on other PD335 variants but isn't testable here. |
+| 19 | `cfgUsbOpen` | no ack, dropped | likewise, no USB on this device |
+| 76 | `cfgAcOutOpen` | no ack, dropped | strategy-doc field number unverified; this device may not have a separate master-AC enable distinct from the AC1/AC2 relays at 380/381 |
+| 377 | `cfgAc2OutOpen` | no ack, dropped | **correct field is 381** (confirmed by app capture). The strategy-doc number was wrong. |
 
-Implications by analogy: the strategy doc's other low-numbered
-ConfigWrite fields (`cfgAcStandbyTime=10`, `cfgDcStandbyTime=11`,
-`cfgScreenOffTime=12`, `cfgDevStandbyTime=13`, `cfgLcdLight=14`, etc.)
-are likely also wrong as written. Do not implement entities for these
-without first capturing the real write traffic.
+Implications by analogy:
+
+- Strategy-doc field numbers for **anything not yet captured** are unreliable.
+  Treat them as starting hypotheses, not facts.
+- The other low-numbered ConfigWrite fields (`cfgAcStandbyTime=10`,
+  `cfgDcStandbyTime=11`, `cfgScreenOffTime=12`, `cfgDevStandbyTime=13`,
+  `cfgLcdLight=14`, etc.) may have the same paired-field requirement
+  as the SOC pair, may use different field numbers, or may not apply
+  to this device at all. Capture before implementing.
 
 ## Capture session: identifying a write field empirically
 

--- a/docs/stream_ac_proto_fields.md
+++ b/docs/stream_ac_proto_fields.md
@@ -53,6 +53,7 @@ tracked separately.
 | 168 | top-level varint (1 or 2) | `feedGridMode` — feed-in control on/off | field 1628 | commit `218ad96` |
 | 380 | top-level varint (0 or 1) | `relay2Onoff` — AC1 relay click | not surfaced yet (field 380 in DisplayPropertyUpload is `plugInInfoPvVol`, an unrelated float — see the note in `stream_ac.py` `switches()`) | commit `218ad96` |
 | 381 | top-level varint (0 or 1) | `relay3Onoff` — AC2 relay (the strategy doc's `cfgAc2OutOpen=377` was wrong) | not surfaced yet | capture 2026-05-26 |
+| 595 | doubly-nested: outer wrapper → inner field 1 → inner-inner SetTimeTaskWrite fields | schedule entry (the strategy doc's `cfgWrite.setTimeTask=39` was wrong; field 595 was the user's earlier hypothesis, confirmed by app capture) | field 584 (same doubly-nested shape) | capture 2026-05-26 |
 
 All work via the existing `_build_proto_command` (single varint),
 `_build_proto_paired_command` (paired varints, for the SOC pair), or
@@ -70,6 +71,59 @@ made Phase C look broken. Captured from the EcoFlow app: it always
 emits both fields together even when only one slider moved. There may
 be other paired-field groups in this device's ConfigWrite vocabulary;
 treat partial-config writes as suspect until verified.
+
+### Schedule entry encoding (field 595 write / field 584 read)
+
+The schedule (`SetTimeTaskWrite` in proto lingo) lives at write field
+**595** and read field **584**. The strategy doc claimed the write was
+at field 39 and the read at field 219; both were wrong for this device.
+The user's earlier hypothesis ("schedule entry in field 595, inner
+fields 2,3,4,5,8,9,10,12") was right, and the strategy doc's dismissal
+of it was the actual error.
+
+Wire shape (both directions):
+
+```
+outer pdata
+└─ field 595 / 584 (wire-type 2)
+   └─ inner field 1 (wire-type 2) — the SetTimeTaskWrite wrapper
+      ├─ inner-inner f2  varint  = taskIndex (slot number; observed = 2
+      │                            on this device with a single entry)
+      ├─ inner-inner f3  varint  = isValid (always 1; explicitly emitted
+      │                            even when value 0 in some encodings)
+      ├─ inner-inner f4  varint  = isEnable (1 = enabled; field is
+      │                            ELIDED from the wire entirely when
+      │                            disabled, even though proto3 would
+      │                            normally permit explicit-0)
+      ├─ inner-inner f5  varint  = isRepeating (always emitted on wire
+      │                            — explicit 0 captured)
+      ├─ inner-inner f8  varint  = timeMode (1 = daily, 2 = weekly;
+      │                            device-specific enum that does NOT
+      │                            match the strategy doc's PD335 enum)
+      ├─ inner-inner f9  varint  = days bitmask, bit0=Mon … bit6=Sun;
+      │                            only meaningful when timeMode ≥ 2
+      ├─ inner-inner f10 bytes[4] = timeTable — a single varint inside
+      │                            the length-delimited field, encoding
+      │                            `(endMinute << 16) | startMinute`
+      └─ inner-inner f12 varint  = power (watts)
+```
+
+**Notably absent**: the schedule entry has **no `type` field**
+(AC_CHG / AC_DSG / AC_TWO_DSG / etc. from the strategy doc's
+`PD335TimeTaskType` enum). Discharge routing on this device is
+controlled at the device level by `feedGridMode` (write field 168):
+
+- `feedGridMode = on (1)` → discharge feeds back to the grid through
+  the bidirectional AC input port
+- `feedGridMode = off (2)` → discharge goes to the AC1 / AC2 output
+  sockets
+
+So "schedule a 400W discharge to the grid Mon-Wed-Fri 10:00-12:00" is
+two settings: the schedule entry above, plus `feedGridMode = 1`.
+
+Inner fields f6, f7, f11 from the strategy doc's `SetTimeTaskWrite`
+mapping (claimed conflictFlag/type/timeMode/timeParam) **do not appear
+in this device's wire format** for either reads or writes.
 
 ## Verified read fields (DisplayPropertyUpload)
 


### PR DESCRIPTION
The EcoFlow Stream AC Pro uses an internal protobuf MQTT API rather than 
the JSON public API for device control. This PR implements bidirectional 
control and state reading for the Stream AC Pro via the internal protocol.


> **🔑 New protocol finding — field 239 is the discharge-strategy enable.** This PR documents a control that (as far as we can find) has not been documented anywhere before: protobuf **field 239** is the EcoFlow app's "semi-automated monitoring" energy strategy, and it is what actually makes the unit discharge to its AC output. **`f239=1` starts discharge, `f239=2` stops it** (1=on / 2=off, same enum as feedGridMode). This was the **missing piece** — feed-in (168) + schedule (595) writes are acked by the device but do **not** cause discharge on their own. Verified on real hardware (see _Tested on_). The **discharge power is load-matched** — it follows the schedule's power field (`field 595` inner `f12`, 100 W resolution), so the battery contributes the scheduled wattage rather than dumping at full power, and the grid covers the rest of the load (no forced export).

## What was reverse-engineered

The internal API uses protobuf commands with cmd_id=17, cmd_func=254, 
discovered by sniffing MQTT traffic via HA debug logs while making 
changes in the EcoFlow app.

### Protocol cheat sheet

| Entity | Write field | Value | Read (state) field |
|---|---|---|---|
| feedGridMode | 168 | 1=enable, 2=disable | 1628 |
| **🔑 Semi-automated discharge** | **239** | **1=on, 2=off** (starts/stops discharge) | — (optimistic) |
| AC1 (relay2Onoff) | 380 | 1=on, 0=off | — (see Still open) |
| AC2 (relay3Onoff) | 381 | 1=on, 0=off | — (see Still open) |
| backupReserveSoc | 102 | 0–100 (%) | 461 |
| Max charge SOC (cmsMaxChgSoc) | 33 (paired with 34) | 50–100 (%) | 270 |
| Min discharge SOC (cmsMinDsgSoc) | 34 (paired with 33) | 0–30 (%) | 271 |
| Operating mode select | 106 (inner field = mode: 1=Self-Powered, 2=Scheduled, 3=TOU, 4=Smart) + empty commit field 546 | — | 393 (radio group) |
| Self-Powered switch (legacy) | 106 (inner 1=on / 2=off) + 546 | — | 393 flag 1 |
| Schedule enable | 595 (`SetTimeTaskWrite`, `isEnable` bit) | on/off | `schedule.summary` |
| Battery SOC (f32ShowSoc) | read-only | — | 6 |

Operating mode and SOC limits write into the nested `cfgEnergyStrategyOperateMode`
sub-message; the two SOC limits (33/34) must be sent together in one pdata or the
device silently rejects the write.

## Changes

- `_build_proto_command(field_num, value)`: constructs protobuf commands 
  with all required header fields
- `_build_proto_paired_command(...)` / `PairedSocNumberEntity`: writes the 
  max-charge (33) and min-discharge (34) SOC limits together in one pdata, 
  since the device rejects either limit sent alone
- `_build_proto_nested_command(...)` driving `ProtoNestedEnabledEntity` and 
  `ProtoNestedRadioSelectEntity` for the nested `cfgEnergyStrategyOperateMode` 
  (field 106): the legacy Self-Powered switch and the 4-option Operating mode 
  select (Self-Powered / Scheduled / TOU / Smart), each followed by the empty 
  field-546 commit marker
- `_build_proto_schedule_command(...)` + `ScheduleEnabledSwitchEntity`: emits a 
  `SetTimeTaskWrite` at field 595 to toggle the active schedule's `isEnable` bit; 
  exposed as a read-only `schedule.summary` sensor plus an enable switch
- `ecoflow_cloud.stream_ac_set_schedule` service (documented in `services.yaml`) 
  for writing schedule entries
- `ProtoEnabledEntity`: subclass of EnabledEntity that sends raw protobuf 
  via MQTT for feedGridMode, AC1 (relay2Onoff / field 380) and AC2 
  (relay3Onoff / field 381)
- **Semi-automated discharge switch** (`ProtoEnabledEntity`, field 239): the
  discharge-strategy enable (`enable_val=1` starts discharge, `disable_val=2`
  stops it). This is the control that actually makes the unit discharge —
  feed-in + schedule alone do not. Adds the `STREAM_SEMI_AUTO_DISCHARGE` const.
- `ProtoBackupReserveEntity`: subclass of BatteryBackupLevel that sends 
  backupReserveSoc via protobuf (field 102) instead of JSON
- Backup reserve number range pinned to a fixed **15–100%** instead of the
  dynamic clamp to the SOC charge/discharge limits (which capped the max at
  `cmsMaxChgSoc`, e.g. 82% — blocking the EcoFlow app's recommended 95% charge
  target). Verified on hardware: 95 is accepted and applied (reads back 95).
- Battery SOC sensor mapped from field 6 (`f32ShowSoc`)
- Power sensors clamp sub-0.01 W float artifacts to 0 so idle ports read a 
  clean 0 W instead of telemetry noise
- `_decode_manual_fields()` + `_RADIO_GROUP_MAP`: extracts state fields not yet 
  in the proto definition (6, 270, 271, 461, 1628) and decodes the field-393 
  radio group into the active operating mode, so HA entities show real values 
  instead of unknown

## Tested on

- EcoFlow Stream AC Pro 
- Home Assistant OS 17.3, Core 2026.5.1
- Physical AC outlet (AC1/AC2 relay) toggle confirmed end-to-end
- **Discharge verified end-to-end via the field-239 switch:** from a stopped
  baseline, toggling it ON (`f239=1`) started discharge (battery 0 → −800 W,
  read field 1628 0→2); toggling OFF (`f239=2`) stopped it (1628→0, battery → 0,
  SOC flat). `f239=0` is acked but does NOT stop discharge — confirming the
  1=on / 2=off enum. Both writes acked by the device (cmd_id 18, `f1=239 f2=1`).
- **Power modulation verified:** schedule `power=200` + field 239 ON → battery
  discharged at **~200 W** (Power Battery −199 W, Power AC +199 W), not the full
  ~800 W; grid imported the remainder of house load (no export). Discharge level
  tracks the schedule power field, confirming load-matched discharge is possible.

## Still open

- Relay on/off read-state field: the AC1/AC2 relay state is not reported at a 
  known telemetry field (field 380 read decodes to `plugInInfoPvVol`, not relay 
  state), so the AC1/AC2 switches show "unknown" until toggled from HA.
- Proto definition not updated: newly decoded state fields go through the 
  `_decode_manual_fields` workaround rather than being declared in 
  `stream_ac.proto`.

AC2 (relay3Onoff) is now implemented — write field 381, captured from the 
EcoFlow app on 2026-05-26.

## Note on inapplicable entities (Stream AC Pro hardware)

For reviewer clarity — several entities that appear in HA under this device 
are not applicable to the Stream AC Pro and are intentionally absent or 
disabled, not missing by oversight:

- **DC 12V Enabled / USB Enabled / AC Enabled** — standard output switches for 
  the delta/river families, defined in `const.py` but not wired up for the 
  Stream AC Pro. The device has no DC 12V or USB ports, and `AC_ENABLED` (a 
  generic master AC toggle) is not exposed by this hardware. None are 
  implemented in `stream_ac.py` and none of this PR's commits add them.
- **AI Mode** (`STREAM_OPERATION_MODE_AI_MODE`) — added upstream in #607, not 
  introduced here. AI Mode is supported by the Stream AC Pro hardware but the 
  HA entity currently shows as unavailable; the #607 implementation requires 
  further work to function correctly on this device. This PR does not modify it.





