### PR TITLE
fix(sensor): drop battery device class from charge/discharge limits

### DIFF
--- a/custom_components/ecoflow_cloud/devices/public/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/public/stream_ac.py
@@ -11,6 +11,7 @@ from custom_components.ecoflow_cloud.devices.public.data_bridge import to_plain
 from custom_components.ecoflow_cloud.number import BatteryBackupLevel
 from custom_components.ecoflow_cloud.sensor import (
     AmpSensorEntity,
+    BatteryLimitSensorEntity,
     CapacitySensorEntity,
     CumulativeCapacitySensorEntity,
     CyclesSensorEntity,
@@ -93,8 +94,8 @@ class StreamAC(BaseDevice):
             # "cmsDsgRemTime": 5939,
             # "cmsMaxChgSoc": 100,
             # "cmsMinDsgSoc": 5,
-            LevelSensorEntity(client, self, "cmsMaxChgSoc", const.MAX_CHARGE_LEVEL),
-            LevelSensorEntity(client, self, "cmsMinDsgSoc", const.MIN_DISCHARGE_LEVEL),
+            BatteryLimitSensorEntity(client, self, "cmsMaxChgSoc", const.MAX_CHARGE_LEVEL),
+            BatteryLimitSensorEntity(client, self, "cmsMinDsgSoc", const.MIN_DISCHARGE_LEVEL),
             # "curSensorNtcNum": 0,
             # "curSensorTemp": [],
             # "cycleSoh": 100.0,

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -134,6 +134,14 @@ class LevelSensorEntity(BaseSensorEntity):
     _attr_suggested_display_precision = 2
 
 
+class BatteryLimitSensorEntity(BaseSensorEntity):
+    # Charge/discharge SoC limits are configuration thresholds, not the amount of
+    # charge left, so they must not use the BATTERY device class (HA defines that
+    # as "percentage of battery that is left").
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+
 class RemainSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES


### PR DESCRIPTION
Max-charge / min-discharge SoC limits are configuration thresholds, not "percentage of battery left", so they shouldn't use `SensorDeviceClass.BATTERY`.

Adds `BatteryLimitSensorEntity` (plain %, no device class) and uses it for the Stream `cmsMaxChgSoc` / `cmsMinDsgSoc` sensors. (Number-entity limits already have no device class.)

**Why:** keeps configuration limits out of Home Assistant's automatic battery grouping.