### PR TITLE
fix(sensor): show SoC with 2-decimal display precision

### DIFF
--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -131,6 +131,7 @@ class LevelSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 2
 
 
 class RemainSensorEntity(BaseSensorEntity):


### PR DESCRIPTION
EcoFlow devices expose fractional SoC (e.g. `f32ShowSoc`). Setting `suggested_display_precision = 2` on `LevelSensorEntity` lets HA render the decimals instead of rounding battery level to whole percent. Display-only; users can still override per entity.