### PR TITLE
fix(mqtt): use paho client for EcoFlow broker

### DIFF
--- a/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
+++ b/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import ssl
+from threading import RLock
 from typing import Any
 
 from homeassistant.core import callback
@@ -21,26 +22,28 @@ class EcoflowMQTTClient:
         self.connected = False
         self.__mqtt_info = mqtt_info
         self.__devices: dict[str, BaseDevice] = devices
+        self.__lock = RLock()
+        self.__client = self.__create_client()
 
-        from homeassistant.components.mqtt.async_client import AsyncMQTTClient
+        self.__connect()
 
-        self.__client: AsyncMQTTClient = AsyncMQTTClient(
+    def __create_client(self) -> Client:
+        client = Client(
             client_id=self.__mqtt_info.client_id,
-            reconnect_on_failure=True,
             clean_session=True,
             callback_api_version=CallbackAPIVersion.VERSION2,
         )
 
-        # self.__client._connect_timeout = 15.0
-        self.__client.setup()
-        self.__client.username_pw_set(self.__mqtt_info.username, self.__mqtt_info.password)
-        self.__client.tls_set(certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED)
-        self.__client.tls_insecure_set(False)
-        self.__client.on_connect = self._on_connect
-        self.__client.on_disconnect = self._on_disconnect
-        self.__client.on_message = self._on_message
-        self.__client.on_socket_close = self._on_socket_close
+        client.username_pw_set(self.__mqtt_info.username, self.__mqtt_info.password)
+        client.tls_set(certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED)
+        client.tls_insecure_set(False)
+        client.on_connect = self._on_connect
+        client.on_disconnect = self._on_disconnect
+        client.on_message = self._on_message
+        client.on_socket_close = self._on_socket_close
+        return client
 
+    def __connect(self) -> None:
         _LOGGER.info(
             f"Connecting to MQTT Broker {self.__mqtt_info.url}:{self.__mqtt_info.port} with client id {self.__mqtt_info.client_id} and username {self.__mqtt_info.username}"
         )
@@ -51,18 +54,26 @@ class EcoflowMQTTClient:
             _LOGGER.exception("Initial EcoFlow MQTT connection timed out; entities will retry reconnect from status updates")
 
     def is_connected(self):
-        return self.__client.is_connected()
+        with self.__lock:
+            return self.__client.is_connected()
 
     def reconnect(self) -> bool:
-        try:
-            _LOGGER.info(f"Re-connecting to MQTT Broker {self.__mqtt_info.url}:{self.__mqtt_info.port}")
-            self.__client.loop_stop()
-            self.__client.reconnect()
-            self.__client.loop_start()
-            return True
-        except Exception as e:
-            _LOGGER.error(e)
-            return False
+        with self.__lock:
+            try:
+                _LOGGER.info(
+                    "Re-creating MQTT client for %s:%s after disconnect",
+                    self.__mqtt_info.url,
+                    self.__mqtt_info.port,
+                )
+                self.connected = False
+                self.__client.loop_stop()
+                self.__client.disconnect()
+                self.__client = self.__create_client()
+                self.__connect()
+                return True
+            except Exception:
+                _LOGGER.exception("Failed to reconnect EcoFlow MQTT client")
+                return False
 
     @callback
     def _on_socket_close(self, client: Client, userdata: Any, sock: Any) -> None:
@@ -75,7 +86,7 @@ class EcoflowMQTTClient:
         if rc == 0:
             self.connected = True
             target_topics = [(topic, 1) for topic in self.__target_topics()]
-            self.__client.subscribe(target_topics)
+            client.subscribe(target_topics)
             _LOGGER.info(f"Subscribed to MQTT topics {target_topics}")
         else:
             self.__log_with_reason("connect", client, userdata, rc)
@@ -110,21 +121,24 @@ class EcoflowMQTTClient:
             _LOGGER.error("Unexpected error processing MQTT message on topic %s", message.topic, exc_info=True)
 
     def stop(self):
-        self.__client.unsubscribe(self.__target_topics())
-        self.__client.loop_stop()
-        self.__client.disconnect()
+        with self.__lock:
+            self.connected = False
+            self.__client.unsubscribe(self.__target_topics())
+            self.__client.loop_stop()
+            self.__client.disconnect()
 
     def __log_with_reason(self, action: str, client, userdata, reason_code: ReasonCode):
         _LOGGER.error(f"MQTT {action}: {reason_code.getName()} ({self.__mqtt_info.client_id}) - {userdata}")
 
     def publish(self, topic: str, message: PayloadType) -> None:
-        try:
-            info = self.__client.publish(topic, message, 1)
-            _LOGGER.debug("Sending " + str(message) + " :" + str(info) + "(" + str(info.is_published()) + ")")
-        except RuntimeError as error:
-            _LOGGER.error("Error on topic %s and message %s: %s", topic, message, error)
-        except Exception as error:
-            _LOGGER.debug("Error on topic %s and message %s: %s", topic, message, error)
+        with self.__lock:
+            try:
+                info = self.__client.publish(topic, message, 1)
+                _LOGGER.debug("Sending " + str(message) + " :" + str(info) + "(" + str(info.is_published()) + ")")
+            except RuntimeError as error:
+                _LOGGER.error("Error on topic %s and message %s: %s", topic, message, error)
+            except Exception:
+                _LOGGER.exception("Error on topic %s and message %s", topic, message)
 
     def __target_topics(self) -> list[str]:
         topics = []


### PR DESCRIPTION
## Summary
- use a plain paho MQTT client for EcoFlow's external broker instead of Home Assistant's internal `AsyncMQTTClient`
- recreate the paho client on reconnect and keep subscribe/publish/reconnect/stop operations serialized around the shared client
- keep the existing status-sensor reconnect scheduling from upstream `#787` unchanged

## Why
EcoFlow MQTT can get stuck after keep-alive timeouts even while a fresh paho client with the same EcoFlow credentials and certified client id can connect and answer `thing/property/get` requests. In that state the integration keeps reporting `offline` / `mqtt_connected=false`, and publishes fail because the HA-wrapped client is not connected.

This path is an external TLS MQTT broker, not HA's local MQTT integration. Using paho directly avoids coupling EcoFlow's broker lifecycle to Home Assistant's internal MQTT client wrapper while preserving the same callback API and topic subscriptions.

## Validation
- `python3 -m ruff check custom_components/ecoflow_cloud/api/ecoflow_mqtt.py`
- `python3 -m py_compile custom_components/ecoflow_cloud/api/ecoflow_mqtt.py`
- `git diff --check`
- live HA 2026.5.4 deploy: `compileall`, `ha core check`, Core restart, EcoFlow status entities online with `mqtt_connected=true`

Head: `ec201ea5e8704be1cce1c677790da65df4f02911`
Base checked: `f6bcce180bae9ada843aed0be1d18f9903c24206`
