### PR TITLE
fix(river3): derive AC output state from flow_info_ac_out

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/river3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river3.py
@@ -443,10 +443,23 @@ class River3(BaseInternalDevice):
             if not merged:
                 return super()._prepare_data(raw_data)
 
-            # River 3 firmware doesn't send cfg_ac_out_open directly;
-            # derive it from output_power_off_memory when available.
-            if "cfg_ac_out_open" not in merged and "output_power_off_memory" in merged:
-                merged["cfg_ac_out_open"] = 1 if merged["output_power_off_memory"] else 0
+            # River 3 firmware doesn't send cfg_ac_out_open directly. The
+            # live AC output state is carried by flow_info_ac_out instead
+            # (verified on a RIVER 3 Plus via MQTT/diagnostics: 2 == output
+            # on, 0 == output off, even with no load attached). Prefer that;
+            # fall back to the output_power_off_memory heuristic (the AC
+            # "always on" memory flag, which only approximates the real
+            # state) when flow_info_ac_out is absent. Both are skipped when
+            # the firmware sends cfg_ac_out_open directly, so that
+            # authoritative value -- like any SetReply -- always wins.
+            if "cfg_ac_out_open" not in merged:
+                ac_flow = merged.get("flow_info_ac_out")
+                if ac_flow in (0, 2):
+                    merged["cfg_ac_out_open"] = 1 if ac_flow == 2 else 0
+                elif ac_flow is None and "output_power_off_memory" in merged:
+                    merged["cfg_ac_out_open"] = (
+                        1 if merged["output_power_off_memory"] else 0
+                    )
 
             flat = self._flatten_dict(merged)
             return {"params": flat, "all_fields": merged}


### PR DESCRIPTION
## Problem

On a **RIVER 3 Plus** (and, as far as I can tell, the base River 3), the **AC Enabled** switch never reflects the real AC-output state — it sits at `unknown`, or tracks the wrong thing.

The cause is in `River3._prepare_data`: River 3 firmware doesn't send `cfg_ac_out_open` in telemetry, so the integration derives it from `output_power_off_memory`. But `output_power_off_memory` is the **AC "always on" memory flag** (a setting), not the live output state — so the switch doesn't reflect whether the inverter is actually delivering AC. In my case the inverter had latched its AC output off while the switch still read "on".

## Fix

Derive `cfg_ac_out_open` from **`flow_info_ac_out`** instead — the same field `delta3.py` already uses for this purpose.

The encoding differs from the Delta 3 (which uses `14`/`4`). On the River 3 Plus I verified via MQTT/diagnostics:

- `flow_info_ac_out == 2` → AC output **on** (holds even with no load attached)
- `flow_info_ac_out == 0` → AC output **off**

Confirmed by toggling the output and watching the derived switch track `2 → 0 → 2`.

The previous `output_power_off_memory` heuristic is kept **only as a fallback** when `flow_info_ac_out` is absent, and a directly-sent `cfg_ac_out_open` (or a `SetReply`) still takes precedence — so this can't regress a base River 3 that already reports state another way. Unknown/transient `flow_info_ac_out` values are ignored rather than guessed.

## Testing

- `python -m py_compile` clean.
- Deployed on HA 2026.6 against a live RIVER 3 Plus: the `AC Enabled` switch now reads `on`/`off` correctly and tracks the output through `turn_off`/`turn_on` cycles (`2 ↔ 0`), where before it stayed `unknown`.

Note: the River 3 Plus isn't auto-detected as `RIVER_3` during setup (it defaults to `ALTERNATOR`); I selected `RIVER 3` manually. Happy to follow up with proper Plus detection in a separate PR if useful.
