### PR TITLE
fix(delta3): correct beeper switch polarity (en_beep is 1 = enabled)

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3.py
@@ -388,6 +388,10 @@ class Delta3(BaseInternalDevice):
                 lambda value: _create_delta3_proto_command(
                     "en_beep", 1 if value else 0, device.device_data.sn, data_len=2
                 ),
+                # en_beep is 1 = beeper enabled, unlike the legacy quiet-mode
+                # keys (beepState) that BeeperEntity inverts by default
+                enableValue=1,
+                disableValue=0,
             ),
             EnabledEntity(
                 client,


### PR DESCRIPTION
## Problem

On DELTA 3 family devices the Beeper switch in Home Assistant is inverted, in both directions:

- When the beeper is OFF in the EcoFlow app, HA shows the switch as ON (and vice versa).
- Toggling the switch in HA does the opposite of its label: turning it "on" actually disables the beeper on the device.

Found while running a DELTA 3 Plus as device type `DELTA_3` (same setup as #775); no existing issue tracks this inversion.

## Cause

`BeeperEntity` defaults to an inverted state mapping (`enableValue=0, disableValue=1`), which is correct for the legacy quiet-mode keys (`pd.beepState` / `mppt.beepState`, where 0 means "beeper active"). The DELTA 3 however uses the protobuf field `en_beep`, whose semantics are direct: 1 = beeper enabled.

Since `EnabledEntity.turn_on()` sends `enableValue` to the command builder, the current code both displays the inverted state and sends the inverted command (turning the switch on sends `en_beep=0`).

## Fix

Pass `enableValue=1, disableValue=0` to the `BeeperEntity` in `devices/internal/delta3.py` so that state mapping and commands match the `en_beep` semantics. The command lambda is unchanged.

## Verification

Tested against a real DELTA 3 Plus (configured as device type `DELTA_3`, private API, on top of v1.5.0-beta3):

- Before: with the beeper disabled in the EcoFlow app, HA displayed the switch as ON; toggling from HA changed the device setting in the opposite direction of the switch label.
- After: the HA switch matches the app state in both directions, and toggling from HA enables/disables the beeper as labeled.

`uv run ruff check .` and `uv run mypy .` pass (same as the Lint workflow).

## Possibly related (not changed here)

The same pattern (BeeperEntity with its default inverted mapping on an `en_beep`-style key) also appears in `internal/river3.py`, `internal/delta_pro_3.py`, `public/delta_pro_3.py`, and (with a doubly-inverted command builder) `internal/wave3.py`. This PR only touches delta3.py because that is the hardware I could verify on; happy to extend if owners of those devices can confirm the behavior.
