### PR TITLE
[codex] Add Stream PV total energy sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1522,7 +1522,7 @@ from Home Assistant.
 - Power PV 2  _(auto)_
 - Power PV 3  _(auto)_
 - Power PV 4  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -1568,7 +1568,7 @@ from Home Assistant.
 - Power PV 2  _(auto)_
 - Power PV 3  _(auto)_
 - Power PV 4  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -1614,7 +1614,7 @@ from Home Assistant.
 - Power PV 2  _(auto)_
 - Power PV 3  _(auto)_
 - Power PV 4  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -2641,7 +2641,7 @@ from Home Assistant.
 - Power PV2 In Amps  _(auto)_
 - Power PV3 In Amps  _(auto)_
 - Power PV4 In Amps  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -2711,7 +2711,7 @@ from Home Assistant.
 - Power PV2 In Amps  _(auto)_
 - Power PV3 In Amps  _(auto)_
 - Power PV4 In Amps  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -2781,7 +2781,7 @@ from Home Assistant.
 - Power PV2 In Amps  _(auto)_
 - Power PV3 In Amps  _(auto)_
 - Power PV4 In Amps  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -348,6 +348,7 @@ STREAM_IN_VOL_PV_2 = "Power PV2 Volts"
 STREAM_IN_VOL_PV_3 = "Power PV3 Volts"
 STREAM_IN_VOL_PV_4 = "Power PV4 Volts"
 STREAM_POWER_PV_SUM = "Power PV Sum"
+STREAM_PV_TOTAL_ENERGY = "PV Total Energy"
 STREAM_GET_SYS_LOAD = "Power Sys Load" # powGetSysLoad
 STREAM_GET_SYS_LOAD_FROM_BP = "Power Sys Load From Battery" # powGetSysLoadFromBp
 STREAM_GET_SYS_LOAD_FROM_GRID = "Power Sys Load From Grid" # powGetSysLoadFromGrid

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -190,7 +190,10 @@ class StreamAC(BaseInternalDevice):
             # "powGetPv4": 0.0,
             WattsSensorEntity(client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True),
             # "powGetPvSum": 2051.3975,
-            WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM),
+            WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM).with_energy(
+                energy_title=const.STREAM_PV_TOTAL_ENERGY,
+                unit_prefix=None,
+            ),
             # "powGetSchuko1": 0.0,
             WattsSensorEntity(client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True),
             # "powGetSchuko2": 18.654325,

--- a/custom_components/ecoflow_cloud/devices/public/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/public/stream_ac.py
@@ -222,7 +222,10 @@ class StreamAC(BaseDevice):
             AmpSensorEntity(client, self, "plugInInfoPv3Amp", const.STREAM_IN_AMPS_PV_3, False, True),
             AmpSensorEntity(client, self, "plugInInfoPv4Amp", const.STREAM_IN_AMPS_PV_4, False, True),
             # "powGetPvSum": 2051.3975,
-            WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM),
+            WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM).with_energy(
+                energy_title=const.STREAM_PV_TOTAL_ENERGY,
+                unit_prefix=None,
+            ),
             # "powGetSchuko1": 0.0,
             WattsSensorEntity(client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True),
             # "powGetSchuko2": 18.654325,

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -311,10 +311,19 @@ class WattsSensorEntity(BaseSensorEntity):
         )
         self._energy_enabled = False
         self._energy_enabled_default = True
+        self._energy_title: str | None = None
+        self._energy_unit_prefix: str | None = "k"
 
-    def with_energy(self, enabled_default: bool = True):
+    def with_energy(
+        self,
+        enabled_default: bool = True,
+        energy_title: str | None = None,
+        unit_prefix: str | None = "k",
+    ):
         self._energy_enabled = True
         self._energy_enabled_default = enabled_default
+        self._energy_title = energy_title
+        self._energy_unit_prefix = unit_prefix
         return self
 
     def energy_enabled(self):
@@ -323,7 +332,12 @@ class WattsSensorEntity(BaseSensorEntity):
     def energy_sensor(self):
         if not self._energy_enabled:
             return None
-        return IntegralEnergySensorEntity(self, self._energy_enabled_default)
+        return IntegralEnergySensorEntity(
+            self,
+            self._energy_enabled_default,
+            self._energy_title,
+            self._energy_unit_prefix,
+        )
 
 
 class EnergySensorEntity(BaseSensorEntity):
@@ -699,15 +713,22 @@ class IntegralEnergySensorEntity(IntegrationSensor):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_entity_registry_visible_default = False
 
-    def __init__(self, base: WattsSensorEntity, enabled_default: bool = True):
+    def __init__(
+        self,
+        base: WattsSensorEntity,
+        enabled_default: bool = True,
+        energy_title: str | None = None,
+        unit_prefix: str | None = "k",
+    ):
+        title = energy_title or base.title().replace(f"{const.POWER}", f" {const.ENERGY}")
         super().__init__(
             base.coordinator.hass,
             integration_method="left",
-            name=f"{base._device.device_info.name} {base.title().replace(f'{const.POWER}', f' {const.ENERGY}')}",
+            name=f"{base._device.device_info.name} {title}",
             round_digits=4,
             source_entity=base.entity_id,
             unique_id=f"{base._attr_unique_id}_energy",
-            unit_prefix="k",
+            unit_prefix=unit_prefix,
             unit_time=UnitOfTime.HOURS,
             max_sub_interval=timedelta(seconds=60),
         )

--- a/docs/devices/STREAM_AC.md
+++ b/docs/devices/STREAM_AC.md
@@ -24,7 +24,7 @@
 - Power PV 2 (`powGetPv2`)   _(auto)_
 - Power PV 3 (`powGetPv3`)   _(auto)_
 - Power PV 4 (`powGetPv4`)   _(auto)_
-- Power PV Sum (`powGetPvSum`)
+- Power PV Sum (`powGetPvSum`) (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1 (`powGetSchuko1`)   _(auto)_
 - Power SCHUKO2 (`powGetSchuko2`)   _(auto)_
 - Power Grid (`powGetSysGrid`)

--- a/docs/devices/STREAM_PRO.md
+++ b/docs/devices/STREAM_PRO.md
@@ -24,7 +24,7 @@
 - Power PV 2 (`powGetPv2`)   _(auto)_
 - Power PV 3 (`powGetPv3`)   _(auto)_
 - Power PV 4 (`powGetPv4`)   _(auto)_
-- Power PV Sum (`powGetPvSum`)
+- Power PV Sum (`powGetPvSum`) (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1 (`powGetSchuko1`)   _(auto)_
 - Power SCHUKO2 (`powGetSchuko2`)   _(auto)_
 - Power Grid (`powGetSysGrid`)

--- a/docs/devices/STREAM_ULTRA.md
+++ b/docs/devices/STREAM_ULTRA.md
@@ -24,7 +24,7 @@
 - Power PV 2 (`powGetPv2`)   _(auto)_
 - Power PV 3 (`powGetPv3`)   _(auto)_
 - Power PV 4 (`powGetPv4`)   _(auto)_
-- Power PV Sum (`powGetPvSum`)
+- Power PV Sum (`powGetPvSum`) (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1 (`powGetSchuko1`)   _(auto)_
 - Power SCHUKO2 (`powGetSchuko2`)   _(auto)_
 - Power Grid (`powGetSysGrid`)

--- a/docs/devices/Stream_AC-Public.md
+++ b/docs/devices/Stream_AC-Public.md
@@ -38,7 +38,7 @@
 - Power PV2 In Amps (`plugInInfoPv2Amp`)   _(auto)_
 - Power PV3 In Amps (`plugInInfoPv3Amp`)   _(auto)_
 - Power PV4 In Amps (`plugInInfoPv4Amp`)   _(auto)_
-- Power PV Sum (`powGetPvSum`)
+- Power PV Sum (`powGetPvSum`) (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1 (`powGetSchuko1`)   _(auto)_
 - Power SCHUKO2 (`powGetSchuko2`)   _(auto)_
 - Power Grid (`powGetSysGrid`)

--- a/docs/devices/Stream_PRO-Public.md
+++ b/docs/devices/Stream_PRO-Public.md
@@ -38,7 +38,7 @@
 - Power PV2 In Amps (`plugInInfoPv2Amp`)   _(auto)_
 - Power PV3 In Amps (`plugInInfoPv3Amp`)   _(auto)_
 - Power PV4 In Amps (`plugInInfoPv4Amp`)   _(auto)_
-- Power PV Sum (`powGetPvSum`)
+- Power PV Sum (`powGetPvSum`) (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1 (`powGetSchuko1`)   _(auto)_
 - Power SCHUKO2 (`powGetSchuko2`)   _(auto)_
 - Power Grid (`powGetSysGrid`)

--- a/docs/devices/Stream_Ultra-Public.md
+++ b/docs/devices/Stream_Ultra-Public.md
@@ -38,7 +38,7 @@
 - Power PV2 In Amps (`plugInInfoPv2Amp`)   _(auto)_
 - Power PV3 In Amps (`plugInInfoPv3Amp`)   _(auto)_
 - Power PV4 In Amps (`plugInInfoPv4Amp`)   _(auto)_
-- Power PV Sum (`powGetPvSum`)
+- Power PV Sum (`powGetPvSum`) (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1 (`powGetSchuko1`)   _(auto)_
 - Power SCHUKO2 (`powGetSchuko2`)   _(auto)_
 - Power Grid (`powGetSysGrid`)

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1465,7 +1465,7 @@
 - Power PV 2  _(auto)_
 - Power PV 3  _(auto)_
 - Power PV 4  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -1511,7 +1511,7 @@
 - Power PV 2  _(auto)_
 - Power PV 3  _(auto)_
 - Power PV 4  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -1557,7 +1557,7 @@
 - Power PV 2  _(auto)_
 - Power PV 3  _(auto)_
 - Power PV 4  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -2584,7 +2584,7 @@
 - Power PV2 In Amps  _(auto)_
 - Power PV3 In Amps  _(auto)_
 - Power PV4 In Amps  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -2654,7 +2654,7 @@
 - Power PV2 In Amps  _(auto)_
 - Power PV3 In Amps  _(auto)_
 - Power PV4 In Amps  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid
@@ -2724,7 +2724,7 @@
 - Power PV2 In Amps  _(auto)_
 - Power PV3 In Amps  _(auto)_
 - Power PV4 In Amps  _(auto)_
-- Power PV Sum
+- Power PV Sum (energy:  _[Device Name]_ PV Total Energy)
 - Power SCHUKO1  _(auto)_
 - Power SCHUKO2  _(auto)_
 - Power Grid


### PR DESCRIPTION
## Summary

- Adds a cumulative `PV Total Energy` sensor for Stream AC-family devices by integrating `powGetPvSum`.
- Keeps the Energy Dashboard source in `Wh` by allowing the integral helper to opt out of the default `k` unit prefix.
- Updates Stream device documentation so the new energy sensor appears alongside `Power PV Sum`.

## Why

Addresses #808. Home Assistant's Energy dashboard needs a cumulative energy statistic, not only the instantaneous PV power value.

## Validation

- Parsed all Python files with Python 3.12 AST parsing: 91 files OK.
- `git diff main..HEAD --check` passed.
- Tested on a live Home Assistant 2026.7.1 instance with a Stream Ultra. The integration loaded successfully and the Energy dashboard accepted `PV Total Energy` as the solar production energy source plus `Power PV Sum` as the optional power source.
