### PR TITLE
fix(delta-pro-3): stop per-frame WARNING spam for routine unparsed frames

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -371,7 +371,14 @@ class DeltaPro3(BaseInternalDevice):
             # 4. Protobuf message decode
             decoded_data = self._decode_message_by_type(decoded_pdata, header_info)
             if not decoded_data:
-                _LOGGER.warning("Message decoding failed")
+                # Routine: devices interleave frames carrying only fields the
+                # proto doesn't declare (or unknown cmdIds).
+                _LOGGER.debug(
+                    "No known fields in message (cmdFunc=%s, cmdId=%s, %d bytes)",
+                    header_info.get("cmdFunc"),
+                    header_info.get("cmdId"),
+                    len(decoded_pdata),
+                )
                 return {}
 
             # 5. Flatten all fields for params
@@ -578,8 +585,9 @@ class DeltaPro3(BaseInternalDevice):
                     _LOGGER.debug(f"Failed to decode as BMSHeartBeatReport (cmdFunc={cmd_func}, cmdId={cmd_id}): {e}")
                     # Fall through to unknown message type
 
-            # Unknown message type - try BMSHeartBeatReport as fallback
-            _LOGGER.warning(f"Unknown message type: cmdFunc={cmd_func}, cmdId={cmd_id}, size={len(pdata)} bytes")
+            # Unknown message type - try BMSHeartBeatReport as fallback.
+            # Routine app-API chatter (one-off cmdIds).
+            _LOGGER.debug(f"Unknown message type: cmdFunc={cmd_func}, cmdId={cmd_id}, size={len(pdata)} bytes")
 
             # Try to decode as BMSHeartBeatReport since that's a common case
             try:


### PR DESCRIPTION
Closes #848

### Problem

DP3-dialect devices routinely interleave frames whose fields the DP3 proto doesn't declare (small delta updates) or one-off cmdIds (observed: 254/19, 254/20, 53/112, 50/2). The decode correctly yields nothing for these, but `_prepare_data` logged a WARNING for every such frame.

### Measured impact

On a 3.2-day production journal with two DP3-dialect devices, **118,171 of 118,467 total HA log lines (99.75%) were `Message decoding failed`** — about 36k/day of noise at the default log level, burying real warnings.

### Change

Downgrade the two per-frame messages (`Message decoding failed`, `Unknown message type`) to DEBUG, adding cmdFunc/cmdId/size context so the frames remain diagnosable with debug logging enabled. Genuine failures (header parse errors, exceptions) keep WARNING/ERROR. No functional change; the BMSHeartBeatReport fallback still runs.

### Testing

Deployed on the measured production instance: journal noise gone; device decode behavior unchanged (same entities, same values). `ruff check`/`ruff format`/`mypy` pass as `mise lint` runs them.