### PR TITLE
Fix Power Kit sub-device discovery (flat /device/quota/all response) — fixes #752

### DIFF
--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -104,7 +104,8 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
 
             from .devices.registry import device_support_sub_devices
 
-            for sn, device_data in self.new_data[CONF_DEVICE_LIST].items():
+            # iterate over a snapshot: the loop mutates new_data[CONF_DEVICE_LIST]
+            for sn, device_data in list(self.new_data[CONF_DEVICE_LIST].items()):
                 if device_data[CONF_DEVICE_TYPE] not in device_support_sub_devices:
                     # skip here all devices that do not support sub devices
                     continue
@@ -113,19 +114,35 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
                 if not isinstance(self.auth, EcoflowPublicApiClient):
                     raise TypeError("Only public api is supported for devices with sub devices")
                 all_device_info = await self.auth.call_api("/device/quota/all", {"sn": sn})
-                for sub_device_type, sub_devices in all_device_info["data"].items():
-                    if not isinstance(sub_devices, dict):
+
+                # The "/device/quota/all" response for a Power Kit is a FLAT dict whose
+                # keys look like "<moduleType>.<moduleSn>.<field>"
+                # (e.g. "bp5000.M101Z3B4ZE5A0737.soc"), with scalar values. Aggregate
+                # keys such as "bmsTotal.<field>" carry no module serial. Older
+                # firmware/API returned a nested dict ({type: {sn: {...}}}); support both.
+                discovered: dict[str, str] = {}  # sub_device_sn -> sub_device_type
+                for key, value in all_device_info["data"].items():
+                    parts = key.split(".")
+                    if len(parts) >= 3:
+                        sub_device_type, sub_device_sn = parts[0], parts[1]
+                        discovered.setdefault(sub_device_sn, sub_device_type)
+                    elif isinstance(value, dict):
+                        # legacy nested shape: {sub_device_type: {sub_device_sn: {...}}}
+                        for sub_device_sn, item in value.items():
+                            if isinstance(item, (dict, list)):
+                                discovered.setdefault(sub_device_sn, key)
+
+                for sub_device_sn, sub_device_type in discovered.items():
+                    if sub_device_sn == sn:
+                        # some modules (e.g. "wireless") report under the parent's
+                        # serial; skip to avoid overwriting the parent device entry
                         continue
-                    for sub_device_sn, item in sub_devices.items():
-                        if not isinstance(item, (dict, list)):
-                            # skip all element that are simple
-                            continue
-                        self.new_data[CONF_DEVICE_LIST][sub_device_sn] = {
-                            CONF_DEVICE_NAME: f"{device_data[CONF_DEVICE_NAME]}.{sub_device_type}.{sub_device_sn}",
-                            CONF_DEVICE_TYPE: sub_device_type,
-                            CONF_PARENT_SN: sn,
-                        }
-                        self.new_options[CONF_DEVICE_LIST][sub_device_sn] = self.new_options[CONF_DEVICE_LIST][sn]
+                    self.new_data[CONF_DEVICE_LIST][sub_device_sn] = {
+                        CONF_DEVICE_NAME: f"{device_data[CONF_DEVICE_NAME]}.{sub_device_type}.{sub_device_sn}",
+                        CONF_DEVICE_TYPE: sub_device_type,
+                        CONF_PARENT_SN: sn,
+                    }
+                    self.new_options[CONF_DEVICE_LIST][sub_device_sn] = self.new_options[CONF_DEVICE_LIST][sn]
 
             return self.async_create_entry(
                 title=self.new_data[CONF_GROUP],


### PR DESCRIPTION
## Problem

Adding a **Power Kit** via the public API creates the device but **no entities** (see #752). All the sub-device sensors (batteries, MPPT, DC/AC hubs, distribution panels) are missing.

## Root cause

Sub-device discovery in `config_flow.py` assumes `/device/quota/all` returns a **nested** dict:

```python
for sub_device_type, sub_devices in all_device_info["data"].items():
    if not isinstance(sub_devices, dict):   # <-- always False for a Power Kit
        continue
    for sub_device_sn, item in sub_devices.items():
        ...
```

But the actual public API response for a Power Kit is a **flat** dict whose keys are `"<moduleType>.<moduleSn>.<field>"` with **scalar** values, e.g.:

```jsonc
{
  "bp5000.M101Z...0737.soc": 98,
  "kitscc.M1096-MPPT-...0003.pv2ErrCode": 0,
  "ldac.M10E1-LDAC-...0193.errorCode": [0, 0, 0, 0, 0],
  "bmsTotal.totalRemainTime": 76,          // aggregate: no module serial
  "wireless.<parentSn>.<field>": ...       // reported under the PARENT serial
}
```

Every value is an `int`/`float`/`str`/`list`, so `isinstance(sub_devices, dict)` is `False` for every key → the inner block never runs → **no sub-devices registered → no entities**. (This regressed vs. the older `paule96` branch, which split the dotted keys.)

There is also a latent `RuntimeError: dictionary changed size during iteration`: the loop mutates `new_data[CONF_DEVICE_LIST]` while iterating it. It never triggered only because nothing was ever added.

## Fix

- Parse the flat dotted keys to discover `(moduleType, moduleSn)` pairs, **keeping backward-compatibility** with the legacy nested shape.
- Skip aggregate keys without a module serial (e.g. `bmsTotal.<field>`).
- Skip modules reported under the **parent's own serial** (e.g. `wireless`) so the parent entry isn't overwritten.
- Iterate over a snapshot of the device list to avoid mutation-during-iteration.

## Testing

Against a real Power Kit `/device/quota/all` response (348 keys), the new logic correctly discovers all 9 real sub-modules and correctly filters out the aggregate keys and the parent-serial `wireless` module:

```
bbcin   M1093-DCIN-...     bbcout  M1093-DCOU-...
bp5000  M101Z...0737       bp5000  M101Z...0272
ichigh  M1095-PSDH-...     iclow   M1095-PSDL-...
kitscc  M1096-MPPT-...     ldac    M10E1-LDAC-...
lddc    M10E1-LDDC-...
```

Each discovered `device_type` maps to an existing handler in `devices/public/powerkit.py` (`bp*`→battery, `iclow`→BMS, `kitscc`→MPPT, `bbcin`/`bbcout`→DC hub, `ichigh`→AC hub, `ldac`/`lddc`→distribution panels).

Fixes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
