### PR TITLE
fix(river2): restore MPPT telemetry diagnostics

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -4,10 +4,41 @@ DC_MODE_OPTIONS = {
     "Car Recharging": 2,
 }
 
+DC_MODE_LABELS = {code: label for label, code in DC_MODE_OPTIONS.items()}
+
 DC_ICONS = {
     "Auto": None,
     "MPPT": "mdi:solar-power",
     "DC": "mdi:current-dc",
+}
+
+# River 2 family FT307 MPPT/DC diagnostic bitmask. EcoFlow exposes these as
+# internal rail/input warnings; the integration keeps them diagnostic-only.
+FT307_FAULTS = {
+    1: {
+        "title": "DC input overvoltage",
+        "hint": "Input voltage is above the supported DC/solar range.",
+    },
+    2: {
+        "title": "DC input undervoltage",
+        "hint": "Input voltage is below the supported DC/solar range.",
+    },
+    4: {
+        "title": "DC input overcurrent",
+        "hint": "Input current is above the supported DC/solar range.",
+    },
+    8: {
+        "title": "DC input overtemperature",
+        "hint": "MPPT/DC input path reports overtemperature.",
+    },
+    16: {
+        "title": "DC input reverse polarity",
+        "hint": "Check DC input polarity before reconnecting the source.",
+    },
+    4096: {
+        "title": "No active DC input",
+        "hint": "Auxiliary idle/no-input warning; ignored when voltage/current/power are idle.",
+    },
 }
 
 SCREEN_TIMEOUT_OPTIONS = {

--- a/custom_components/ecoflow_cloud/devices/internal/river2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2.py
@@ -16,9 +16,10 @@ from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
+    DcModeStateSensorEntity,
+    Ft307FaultCodeSensorEntity,
     InMilliampSensorEntity,
     InMilliVoltSensorEntity,
-    InVoltSensorEntity,
     InWattsSensorEntity,
     LevelSensorEntity,
     MilliVoltSensorEntity,
@@ -53,8 +54,10 @@ class River2(BaseInternalDevice):
             ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER).with_energy(),
-            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
+            # River 2 reports live PV telemetry under mppt.*; inv.dcIn* stays at 0
+            # even while solar input power is non-zero.
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT, entity_key="inv.dcInAmp"),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE, entity_key="inv.dcInVol"),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER).with_energy(),
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
@@ -64,6 +67,15 @@ class River2(BaseInternalDevice):
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
+            # River 2 family exposes only the user-facing 12V/car output toggle.
+            # These mppt.* fields are still useful diagnostics for understanding
+            # which DC path is active and whether the internal 24V rail is alive,
+            # but they are not a confirmed switchable 24V output like Delta Pro 3.
+            # Keep the configured-key unique ID so the runtime sensor does not respawn under a new entity ID.
+            DcModeStateSensorEntity(
+                client, self, "mppt.chgType", "DC Mode", diagnostic=True, entity_key="mppt.cfgChgType"
+            ),
+            Ft307FaultCodeSensorEntity(client, self, "mppt.faultCode", "MPPT Fault", diagnostic=True),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
             RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),

--- a/custom_components/ecoflow_cloud/devices/internal/river2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_max.py
@@ -16,9 +16,10 @@ from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
+    DcModeStateSensorEntity,
+    Ft307FaultCodeSensorEntity,
     InMilliampSensorEntity,
     InMilliVoltSensorEntity,
-    InVoltSensorEntity,
     InWattsSensorEntity,
     LevelSensorEntity,
     MilliVoltSensorEntity,
@@ -53,8 +54,10 @@ class River2Max(BaseInternalDevice):
             ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER).with_energy(),
-            InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
+            # River 2 reports live PV telemetry under mppt.*; inv.dcIn* stays at 0
+            # even while solar input power is non-zero.
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT, entity_key="inv.dcInAmp"),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE, entity_key="inv.dcInVol"),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER).with_energy(),
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
@@ -64,6 +67,15 @@ class River2Max(BaseInternalDevice):
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
+            # River 2 family exposes only the user-facing 12V/car output toggle.
+            # These mppt.* fields are still useful diagnostics for understanding
+            # which DC path is active and whether the internal 24V rail is alive,
+            # but they are not a confirmed switchable 24V output like Delta Pro 3.
+            # Keep the configured-key unique ID so the runtime sensor does not respawn under a new entity ID.
+            DcModeStateSensorEntity(
+                client, self, "mppt.chgType", "DC Mode", diagnostic=True, entity_key="mppt.cfgChgType"
+            ),
+            Ft307FaultCodeSensorEntity(client, self, "mppt.faultCode", "MPPT Fault", diagnostic=True),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
             RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),

--- a/custom_components/ecoflow_cloud/devices/internal/river2_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_pro.py
@@ -16,6 +16,9 @@ from custom_components.ecoflow_cloud.sensor import (
     CapacitySensorEntity,
     ChargingStateSensorEntity,
     CyclesSensorEntity,
+    DcModeStateSensorEntity,
+    Ft307FaultCodeSensorEntity,
+    InMilliampSensorEntity,
     InMilliVoltSensorEntity,
     InWattsSensorEntity,
     LevelSensorEntity,
@@ -55,10 +58,21 @@ class River2Pro(BaseInternalDevice):
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
             InWattsSensorEntity(client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER),
+            InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT, entity_key="inv.dcInAmp"),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE, entity_key="inv.dcInVol"),
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER).with_energy(),
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
+            # River 2 family exposes only the user-facing 12V/car output toggle.
+            # These mppt.* fields are still useful diagnostics for understanding
+            # which DC path is active and whether the internal 24V rail is alive,
+            # but they are not a confirmed switchable 24V output like Delta Pro 3.
+            # Keep the configured-key unique ID so the runtime sensor does not respawn under a new entity ID.
+            DcModeStateSensorEntity(
+                client, self, "mppt.chgType", "DC Mode", diagnostic=True, entity_key="mppt.cfgChgType"
+            ),
+            Ft307FaultCodeSensorEntity(client, self, "mppt.faultCode", "MPPT Fault", diagnostic=True),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
             RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -94,8 +94,9 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         enabled: bool = True,
         auto_enable: bool = False,
         diagnostic: Optional[bool] = None,
+        entity_key: str | None = None,
     ):
-        super().__init__(client, device, title, mqtt_key)
+        super().__init__(client, device, title, entity_key or mqtt_key)
 
         self.__mqtt_key = mqtt_key
         self._mqtt_key_adopted = self._adopt_json_key(mqtt_key)
@@ -269,8 +270,9 @@ class BaseSensorEntity(SensorEntity, EcoFlowDictEntity):  # type: ignore[misc]
         enabled: bool = True,
         auto_enable: bool = False,
         diagnostic: Optional[bool] = None,
+        entity_key: str | None = None,
     ):
-        super().__init__(client, device, mqtt_key, title, enabled, auto_enable, diagnostic)
+        super().__init__(client, device, mqtt_key, title, enabled, auto_enable, diagnostic, entity_key)
         if self._attr_default_value is not None:
             self._attr_native_value = self._attr_default_value
 

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -131,6 +131,152 @@ class MiscSensorEntity(BaseSensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
 
+class DcModeStateSensorEntity(MiscSensorEntity):
+    """Expose the live DC input mode without duplicating the config select."""
+
+    _attr_icon = "mdi:tune-variant"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw_code: int | None = None
+
+    def _runtime_mode(self) -> tuple[int | None, str | None]:
+        params = self._device.data.params
+        runtime_code = params.get("mppt.chgType")
+        if runtime_code is None:
+            return None, None
+        runtime_code = int(runtime_code)
+        if runtime_code == 255:
+            return runtime_code, "No active DC input"
+        return runtime_code, const.DC_MODE_LABELS.get(runtime_code, f"Unknown ({runtime_code})")
+
+    @property
+    def icon(self) -> str | None:
+        if self._raw_code == 255:
+            return "mdi:power-plug-off-outline"
+        if self._raw_code == const.DC_MODE_OPTIONS["Solar Recharging"]:
+            return "mdi:solar-power"
+        if self._raw_code == const.DC_MODE_OPTIONS["Car Recharging"]:
+            return "mdi:car-electric"
+        if self._raw_code == const.DC_MODE_OPTIONS["Auto"]:
+            return "mdi:tune-variant"
+        return "mdi:help-circle-outline"
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs["raw_code"] = self._raw_code
+        configured_code = self._device.data.params.get("mppt.cfgChgType")
+        if configured_code is not None:
+            configured_code = int(configured_code)
+        attrs["configured_code"] = configured_code
+        attrs["configured_mode"] = (
+            const.DC_MODE_LABELS.get(configured_code, f"Unknown ({configured_code})")
+            if configured_code is not None
+            else None
+        )
+        runtime_code, runtime_mode = self._runtime_mode()
+        attrs["runtime_code"] = runtime_code
+        attrs["runtime_mode"] = runtime_mode
+        return attrs
+
+    def _update_value(self, val: Any) -> bool:
+        runtime_code = int(val)
+        runtime_mode = self._runtime_mode()[1]
+        self._raw_code = runtime_code
+        label = runtime_mode or f"Unknown ({runtime_code})"
+        return super()._update_value(label)
+
+    def _updated(self, data: dict[str, Any]):
+        params = self._device.data.params
+        runtime_code = params.get("mppt.chgType")
+        if runtime_code is None:
+            return
+
+        self._attr_available = True
+        if self._update_value(runtime_code):
+            self.schedule_update_ha_state()
+
+
+class Ft307FaultCodeSensorEntity(MiscSensorEntity):
+    """Decode the FT307 MPPT/DC fault bitmask into readable diagnostics."""
+
+    _attr_icon = "mdi:check-circle-outline"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw_code: int | None = None
+        self._active_faults: list[dict[str, Any]] = []
+        self._unknown_bits: int = 0
+        self._suppressed_faults: list[dict[str, Any]] = []
+
+    def _dc_input_is_effectively_idle(self) -> bool:
+        params = self._device.data.params
+        in_watts = int(params.get("mppt.inWatts", 0) or 0)
+        in_vol = int(params.get("mppt.inVol", 0) or 0)
+        in_amp = int(params.get("mppt.inAmp", 0) or 0)
+        return in_watts == 0 and in_vol < 5000 and in_amp < 100
+
+    @property
+    def icon(self) -> str | None:
+        if self._active_faults:
+            return "mdi:alert-octagon-outline"
+        if self._suppressed_faults:
+            return "mdi:minus-circle-outline"
+        return self._attr_icon
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        attrs = dict(super().extra_state_attributes or {})
+        attrs["raw_code"] = self._raw_code
+        attrs["active_faults"] = self._active_faults
+        if self._suppressed_faults:
+            attrs["suppressed_faults"] = self._suppressed_faults
+        if self._unknown_bits:
+            attrs["unknown_bits"] = self._unknown_bits
+        return attrs
+
+    def _update_value(self, val: Any) -> bool:
+        code = int(val)
+        self._raw_code = code
+        self._active_faults = []
+        self._unknown_bits = 0
+        self._suppressed_faults = []
+
+        if code == 0:
+            return super()._update_value("No fault")
+
+        known_mask = 0
+        for bit, meta in sorted(const.FT307_FAULTS.items()):
+            known_mask |= bit
+            if not (code & bit):
+                continue
+            fault = {"bit": bit, "title": meta["title"], "hint": meta["hint"]}
+            if bit == 4096 and self._dc_input_is_effectively_idle():
+                self._suppressed_faults.append(fault)
+                continue
+            self._active_faults.append(fault)
+
+        self._unknown_bits = code & ~known_mask
+        if self._unknown_bits:
+            self._active_faults.append(
+                {
+                    "bit": self._unknown_bits,
+                    "title": f"Unknown fault bits (0x{self._unknown_bits:X})",
+                    "hint": None,
+                }
+            )
+
+        if not self._active_faults and self._suppressed_faults:
+            return super()._update_value("No active DC fault")
+        if len(self._active_faults) == 1:
+            label = self._active_faults[0]["title"]
+        else:
+            label = "; ".join(fault["title"] for fault in self._active_faults)
+
+        return super()._update_value(label)
+
+
 class LevelSensorEntity(BaseSensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE

--- a/docs/devices/RIVER_2.md
+++ b/docs/devices/RIVER_2.md
@@ -10,8 +10,8 @@
 - Battery Charging State (`bms_emsStatus.chgState`)
 - Total In Power (`pd.wattsInSum`) (energy:  _[Device Name]_ Total In  Energy)
 - Total Out Power (`pd.wattsOutSum`) (energy:  _[Device Name]_ Total Out  Energy)
-- Solar In Current (`inv.dcInAmp`)
-- Solar In Voltage (`inv.dcInVol`)
+- Solar In Current (`mppt.inAmp`)
+- Solar In Voltage (`mppt.inVol`)
 - AC In Power (`inv.inputWatts`) (energy:  _[Device Name]_ AC In  Energy)
 - AC Out Power (`inv.outputWatts`) (energy:  _[Device Name]_ AC Out  Energy)
 - AC In Volts (`inv.acInVol`)
@@ -21,6 +21,8 @@
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typec1Watts`)
 - USB Out Power (`pd.usb1Watts`)
+- DC Mode (`mppt.chgType`)   _(diagnostic; state shows the live runtime mode, attributes still include configured/runtime raw values, and runtime `255` is shown as `No active DC input`)_
+- MPPT Fault (`mppt.faultCode`)   _(diagnostic; decoded title with raw bitmask in attributes, with idle/no-input auxiliary warnings suppressed into attributes instead of shown as active faults)_
 - Charge Remaining Time (`bms_emsStatus.chgRemainTime`)
 - Discharge Remaining Time (`bms_emsStatus.dsgRemainTime`)
 - Remaining Time (`pd.remainTime`)
@@ -54,4 +56,4 @@
 - Unit Timeout (`mppt.powStandbyMin` -> `{"moduleType": 5, "operateType": "standby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 - AC Timeout (`mppt.acStandbyMins` -> `{"moduleType": 5, "operateType": "acStandby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
-
+_Note: River 2 family exposes a user-facing DC (12V/car) output via `pd.carState`, but there is no confirmed dedicated 24V output control path like Delta Pro 3 `cfgDc24vOutOpen`._

--- a/docs/devices/RIVER_2_MAX.md
+++ b/docs/devices/RIVER_2_MAX.md
@@ -10,8 +10,8 @@
 - Battery Charging State (`bms_emsStatus.chgState`)
 - Total In Power (`pd.wattsInSum`) (energy:  _[Device Name]_ Total In  Energy)
 - Total Out Power (`pd.wattsOutSum`) (energy:  _[Device Name]_ Total Out  Energy)
-- Solar In Current (`inv.dcInAmp`)
-- Solar In Voltage (`inv.dcInVol`)
+- Solar In Current (`mppt.inAmp`)
+- Solar In Voltage (`mppt.inVol`)
 - AC In Power (`inv.inputWatts`) (energy:  _[Device Name]_ AC In  Energy)
 - AC Out Power (`inv.outputWatts`) (energy:  _[Device Name]_ AC Out  Energy)
 - AC In Volts (`inv.acInVol`)
@@ -21,6 +21,8 @@
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typec1Watts`)
 - USB Out Power (`pd.usb1Watts`)
+- DC Mode (`mppt.chgType`)   _(diagnostic; state shows the live runtime mode, attributes still include configured/runtime raw values, and runtime `255` is shown as `No active DC input`)_
+- MPPT Fault (`mppt.faultCode`)   _(diagnostic; decoded title with raw bitmask in attributes, with idle/no-input auxiliary warnings suppressed into attributes instead of shown as active faults)_
 - Charge Remaining Time (`bms_emsStatus.chgRemainTime`)
 - Discharge Remaining Time (`bms_emsStatus.dsgRemainTime`)
 - Remaining Time (`pd.remainTime`)
@@ -54,4 +56,4 @@
 - Unit Timeout (`mppt.powStandbyMin` -> `{"moduleType": 5, "operateType": "standby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 - AC Timeout (`mppt.acStandbyMins` -> `{"moduleType": 5, "operateType": "acStandby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
-
+_Note: River 2 family exposes a user-facing DC (12V/car) output via `pd.carState`, but there is no confirmed dedicated 24V output control path like Delta Pro 3 `cfgDc24vOutOpen`._

--- a/docs/devices/RIVER_2_PRO.md
+++ b/docs/devices/RIVER_2_PRO.md
@@ -15,10 +15,14 @@
 - AC In Volts (`inv.acInVol`)
 - AC Out Volts (`inv.invOutVol`)
 - Type-C In Power (`pd.typecChaWatts`)
+- Solar In Current (`mppt.inAmp`)
+- Solar In Voltage (`mppt.inVol`)
 - Solar In Power (`mppt.inWatts`) (energy:  _[Device Name]_ Solar In  Energy)
 - DC Out Power (`pd.carWatts`)
 - Type-C Out Power (`pd.typec1Watts`)
 - USB Out Power (`pd.usb1Watts`)
+- DC Mode (`mppt.chgType`)   _(diagnostic; state shows the live runtime mode, attributes still include configured/runtime raw values, and runtime `255` is shown as `No active DC input`)_
+- MPPT Fault (`mppt.faultCode`)   _(diagnostic; decoded title with raw bitmask in attributes, with idle/no-input auxiliary warnings suppressed into attributes instead of shown as active faults)_
 - Charge Remaining Time (`bms_emsStatus.chgRemainTime`)
 - Discharge Remaining Time (`bms_emsStatus.dsgRemainTime`)
 - Remaining Time (`pd.remainTime`)
@@ -51,4 +55,4 @@
 - Unit Timeout (`mppt.powStandbyMin` -> `{"moduleType": 5, "operateType": "standby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 - AC Timeout (`mppt.acStandbyMins` -> `{"moduleType": 5, "operateType": "acStandby", "params": {"standbyMins": "VALUE"}}` [Never (0), 30 min (30), 1 hr (60), 2 hr (120), 4 hr (240), 6 hr (360), 12 hr (720), 24 hr (1440)])
 
-
+_Note: River 2 family exposes a user-facing DC (12V/car) output via `pd.carState`, but there is no confirmed dedicated 24V output control path like Delta Pro 3 `cfgDc24vOutOpen`._


### PR DESCRIPTION
## Summary
- Restore River 2 / River 2 Max solar current and voltage from live `mppt.inAmp` / `mppt.inVol` telemetry while preserving the existing `inv.dcIn*` entity unique IDs.
- Add matching River 2 Pro solar current and voltage sensors.
- Add diagnostic River 2 family DC mode and FT307 MPPT fault sensors.
- Document the River 2 DC/MPPT telemetry mapping and keep 12V/car output separate from unconfirmed 24V output control.

## Why
On River 2 family devices, the old `inv.dcIn*` keys can stay at zero even while `mppt.inWatts` reports active solar input. The live MPPT keys carry the useful voltage/current telemetry, so the sensors should read from `mppt.*` without respawning user-visible entities.

This is a focused rebuild from `Komzpa/hassio-ecoflow-cloud:codex/river2-energy-fixes` commit `d1201d18988307759ead692fb6d3094328e9aa25`. It intentionally leaves the offline availability/status-propagation changes from `tolwi/hassio-ecoflow-cloud#769` out of this PR so the telemetry fix can be reviewed separately.

## Validation
- `python3 -m py_compile custom_components/ecoflow_cloud/devices/const.py custom_components/ecoflow_cloud/entities/__init__.py custom_components/ecoflow_cloud/sensor.py custom_components/ecoflow_cloud/devices/internal/river2.py custom_components/ecoflow_cloud/devices/internal/river2_max.py custom_components/ecoflow_cloud/devices/internal/river2_pro.py`
- `python3 -m ruff check custom_components/ecoflow_cloud/devices/const.py custom_components/ecoflow_cloud/entities/__init__.py custom_components/ecoflow_cloud/sensor.py custom_components/ecoflow_cloud/devices/internal/river2.py custom_components/ecoflow_cloud/devices/internal/river2_max.py custom_components/ecoflow_cloud/devices/internal/river2_pro.py`
- `git diff --check`
