### PR TITLE
fix(mqtt): tolerate initial connect timeout

### DIFF
--- a/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
+++ b/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
@@ -44,8 +44,11 @@ class EcoflowMQTTClient:
         _LOGGER.info(
             f"Connecting to MQTT Broker {self.__mqtt_info.url}:{self.__mqtt_info.port} with client id {self.__mqtt_info.client_id} and username {self.__mqtt_info.username}"
         )
-        self.__client.connect(self.__mqtt_info.url, self.__mqtt_info.port, keepalive=15)
-        self.__client.loop_start()
+        try:
+            self.__client.connect(self.__mqtt_info.url, self.__mqtt_info.port, keepalive=15)
+            self.__client.loop_start()
+        except TimeoutError:
+            _LOGGER.exception("Initial EcoFlow MQTT connection timed out; entities will retry reconnect from status updates")
 
     def is_connected(self):
         return self.__client.is_connected()


### PR DESCRIPTION
## Summary
- Catch initial EcoFlow MQTT `TimeoutError` during config entry setup.
- Let the integration finish loading entities so existing reconnect/status paths can retry later.

## Why
A transient MQTT broker timeout during `EcoflowMQTTClient` startup currently bubbles out of config entry setup. That leaves the whole `ecoflow_cloud` entry failed instead of loading entities and retrying the broker connection.

## Validation
- `python3 -m py_compile custom_components/ecoflow_cloud/api/ecoflow_mqtt.py`
- `python3 -m ruff check custom_components/ecoflow_cloud/api/ecoflow_mqtt.py`
- `git diff --check`
- Live HA verification on the same failure mode: after applying the equivalent hotfix and restarting Core, the EcoFlow entry loaded and both configured UPS devices returned online.
