### PR TITLE
fix(stream): decode battery SoC on Stream Pro (bare Champ_cmd21_2)

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -362,6 +362,17 @@ class StreamAC(BaseInternalDevice):
                     if packet.msg.cmd_id > 0:
                         self._parsedata(packet, stream_ac2.StreamACChamp_cmd21(), raw)
 
+                    # Battery telemetry, in whichever shape this model uses.
+                    # Normalised here rather than at the end of the method: the
+                    # parses below re-read the same pdata as unrelated message
+                    # types and overwrite the "Champ_cmd21_2_field*" keys with
+                    # garbage, so the canonical keys have to be pinned first.
+                    if packet.msg.cmd_id > 0:
+                        champ_cmd21_2 = self._extract_champ_cmd21_2(packet, stream_ac2)
+                        if champ_cmd21_2 is not None:
+                            self._store_fields(champ_cmd21_2, raw)
+                            self._normalize_champ_fields(raw["params"])
+
                     # paquet Champ_cmd21_3
                     if packet.msg.cmd_id > 0:
                         self._parsedata(packet, stream_ac2.StreamACChamp_cmd21_3(), raw)
@@ -393,7 +404,6 @@ class StreamAC(BaseInternalDevice):
                 str(raw_data),
                 str(raw_data.hex()),
             )
-        self._normalize_champ_fields(raw["params"])
         return raw
 
     # Newer Stream firmware / models (e.g. Stream Ultra / Ultra X) do not emit
@@ -421,6 +431,65 @@ class StreamAC(BaseInternalDevice):
         for canonical, nested in self._CHAMP_FIELD_ALIASES.items():
             if nested in params and params.get(canonical) is None:
                 params[canonical] = params[nested]
+
+    # Percentage-valued leaves, used to sanity-check a bare Champ_cmd21_2
+    # decode before trusting it.
+    _CHAMP_PERCENT_FIELDS = (
+        "Champ_cmd21_2_field9",  # soc
+        "Champ_cmd21_2_field15",  # f32ShowSoc
+        "Champ_cmd21_2_field7",  # cmsMaxChgSoc
+        "Champ_cmd21_2_field21",  # cmsMinDsgSoc
+    )
+
+    def _extract_champ_cmd21_2(self, packet, stream_ac2):
+        """Return the Champ_cmd21_2 message a frame carries, or None.
+
+        Stream AC / Ultra / Ultra X wrap it in Champ_cmd21 as field 1, but
+        Stream Pro emits it bare - the whole pdata *is* the Champ_cmd21_2, with
+        no wrapper. Parsing that as Champ_cmd21 yields an entirely empty
+        message, which is why the battery leaves never reached the sensors on
+        that model. Prefer the wrapped form, fall back to the bare one.
+
+        Every frame this device sends will parse as *some* Champ_cmd21_2, so
+        both candidates are sanity-checked before being trusted: an unrelated
+        frame reinterpreted under this schema nearly always lands outside 0-100
+        on at least one percentage leaf.
+        """
+        pdata = getattr(packet.msg, "pdata", b"")
+        if not pdata:
+            return None
+
+        candidates = []
+
+        try:
+            wrapped = stream_ac2.StreamACChamp_cmd21()
+            wrapped.ParseFromString(pdata)
+            if wrapped.HasField("Champ_cmd21_champ_cmd21_2"):
+                candidates.append(wrapped.Champ_cmd21_champ_cmd21_2)
+        except Exception as error:
+            _LOGGER.debug(error)
+
+        try:
+            bare = stream_ac2.StreamACChamp_cmd21_2()
+            bare.ParseFromString(pdata)
+            candidates.append(bare)
+        except Exception as error:
+            _LOGGER.debug(error)
+
+        for candidate in candidates:
+            if self._looks_like_battery_telemetry(candidate):
+                return candidate
+
+        return None
+
+    @classmethod
+    def _looks_like_battery_telemetry(cls, msg) -> bool:
+        if not msg.HasField("Champ_cmd21_2_field9"):
+            return False
+        for name in cls._CHAMP_PERCENT_FIELDS:
+            if msg.HasField(name) and not 0 <= getattr(msg, name) <= 100:
+                return False
+        return True
 
     def _parsedata(self, packet, content, raw):
         try:


### PR DESCRIPTION
## Problem

On **Stream Pro** (`STREAM_PRO`, private API) every battery sensor is empty — `soc`, `f32ShowSoc`, `bmsDsgRemTime`, `cmsMaxChgSoc` and `cmsMinDsgSoc` never get a value.

The cause is a pdata shape that `_prepare_data` doesn't handle. Stream AC / Ultra / Ultra X wrap `Champ_cmd21_2` inside `Champ_cmd21` as field 1, and #846 correctly decodes that. Stream Pro emits `Champ_cmd21_2` **bare** — the whole pdata *is* the `Champ_cmd21_2`, with no wrapper.

Parsing that as `Champ_cmd21` produces an entirely empty message, so `_store_fields()` stores nothing and `_normalize_champ_fields()` has no `Champ_cmd21_2_field*` keys to alias from.

Replaying a real frame captured from my unit:

```
### as StreamACChamp_cmd21 (what main currently tries):
   <EMPTY - nothing decoded>
   HasField(Champ_cmd21_champ_cmd21_2) = False

### as StreamACChamp_cmd21_2 (top-level, no wrapper):
   Champ_cmd21_2_field7: 100      -> cmsMaxChgSoc
   Champ_cmd21_2_field9: 76       -> soc
   Champ_cmd21_2_field13: 497     -> bmsDsgRemTime
   Champ_cmd21_2_field15: 76.321  -> f32ShowSoc
   Champ_cmd21_2_field21: 5       -> cmsMinDsgSoc
```

The values were there all along under the field numbers #846 established — just never reached, because nothing parses that shape.

## Changes

**1. Handle both shapes.** `_extract_champ_cmd21_2()` tries the wrapped form first and falls back to the bare one. Since *any* pdata will happily parse as some `Champ_cmd21_2`, both candidates are range-checked against their percentage leaves (fields 7/9/15/21) before being trusted, so an unrelated frame can't masquerade as battery telemetry.

**2. Normalise earlier.** `_normalize_champ_fields()` ran at the tail of `_prepare_data`, *after* the same pdata had been re-read as `Champ_cmd21_3`, `Champ_cmd50` and `Champ_cmd50_3`. Those cross-parses overwrite the `Champ_cmd21_2_field*` keys, so the aliases could pick up a SoC from an unrelated frame. Reproduced on synthetic frames: a genuine cmd21 frame reporting `soc=46` followed by a cmd50 frame ends up reporting `soc=12`, because field 1 of the cmd50 payload is reinterpreted as `Champ_cmd21_2` and its field 9 becomes a plausible-looking but wrong SoC. Moving normalisation to directly after the extraction pins the canonical keys to the correctly typed values first.

## Testing

Verified against the real captured frame plus the wrapped shape and a negative case:

| case | soc | f32ShowSoc | cmsMaxChgSoc | cmsMinDsgSoc |
|---|---|---|---|---|
| real Stream Pro frame (bare) | 76 | 76.321 | 100 | 5 |
| wrapped (AC / Ultra / Ultra X) | 46 | 46.318 | 100 | 5 |
| unrelated cmd50 frame | None | None | None | None |

The Ultra X path from #846 is unchanged — same field numbers, same alias table, same sensors. No entities added or renamed, so no doc regeneration needed.

- `ruff check --ignore "$RUFF_DEFERRED" .` — passes
- `mypy` — no errors in `stream_ac.py` (I couldn't run the full `mise run lint` locally: `uv sync` fails to build `lru-dict` on my machine for lack of `Python.h`, so mypy ran with `--ignore-missing-imports` on the file rather than against the real HA stubs)
- Running on Home Assistant 2026.8.1 / HAOS 18.2 against a live Stream Pro

## Notes

`bmsDsgRemTime` maps to field 13, which reads 497 (≈8.3 h) on my unit — plausible at 76% SoC, but I've left #846's mapping untouched rather than second-guess it. Field 12 reads 5939, which `RemainSensorEntity` would clamp to 0 anyway.

Happy to adjust naming or split the two changes into separate commits if you'd prefer.
