### PR TITLE
fix: stop fabricating 0 for offline STREAM microinverter sensors

### DIFF
--- a/custom_components/ecoflow_cloud/devices/__init__.py
+++ b/custom_components/ecoflow_cloud/devices/__init__.py
@@ -92,6 +92,11 @@ class BaseDevice(ABC):
     def flat_json(self) -> bool:
         return True
 
+    def reset_sensors_when_offline(self) -> bool:
+        """Whether measurement sensors should fall back to their default value
+        (usually 0) while the device is considered offline."""
+        return True
+
     async def async_restore_state(self):
         """Restore persisted device state on startup. Override in subclasses."""
         pass

--- a/custom_components/ecoflow_cloud/devices/public/stream_microinverter.py
+++ b/custom_components/ecoflow_cloud/devices/public/stream_microinverter.py
@@ -22,6 +22,14 @@ from custom_components.ecoflow_cloud.devices.public.stream_pv_helpers import (
 
 
 class StreamMicroinveter(BaseDevice):
+    def reset_sensors_when_offline(self) -> bool:
+        # The Stream family pushes over the Public API irregularly (as
+        # infrequently as every ~15 min while idle), and /device/quota/all
+        # returns an empty dataset for this device. "Offline" is therefore
+        # not a reliable signal here, and holding the last known measurement
+        # is more honest than fabricating a 0. See issues #696 and #651.
+        return False
+
     def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
         return [
             WattsSensorEntity(client, self, "gridConnectionPower", const.STREAM_POWER_AC),

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import inspect
 from typing import Any, Callable, Mapping, Optional, OrderedDict, Self, cast
 
@@ -142,11 +143,19 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
     def _handle_coordinator_update(self) -> None:
         if self.coordinator.data.changed:
             self._updated(self.coordinator.data.data_holder.params)
-        elif self._device.status_tracker.is_offline:  # Device is offline
+        elif self._device.status_tracker.is_offline and self._device.reset_sensors_when_offline():  # Device is offline
             # Reset sensors that should reset to default values
             if isinstance(self, BaseSensorEntity) and self._attr_default_value is not None:
-                self._mqtt_key_expr.update(self.coordinator.data.data_holder.params, self._attr_default_value)
-                self._updated(self.coordinator.data.data_holder.params)
+                # Work on a deep copy so the shared data_holder.params dict -
+                # and every other entity/diagnostics view backed by it - is
+                # never mutated with a fabricated default value. A shallow
+                # {**params, key: value} copy is not enough here because
+                # self._mqtt_key_expr may address a nested path (flat_json()
+                # == False), so we let the already-parsed jsonpath expression
+                # update a full copy of the params tree instead.
+                params_copy = copy.deepcopy(self.coordinator.data.data_holder.params)
+                self._mqtt_key_expr.update(params_copy, self._attr_default_value)
+                self._updated(params_copy)
 
     def _updated(self, data: dict[str, Any]):
         # update attributes


### PR DESCRIPTION
## Problem

Stream Microinverter (BK-series) reports over the Public API with an irregular cadence — sometimes 5-15 minutes between pushes — and `/device/quota/all` returns an empty dataset for this device (confirmed empty `data: {}` response on a live device). Combined with the default `assume_offline_sec` of 300s, the device is frequently marked `assume_offline`/`offline` even while it's actively producing power.

When that happens, `EcoFlowDictEntity._handle_coordinator_update` resets every sensor with an `_attr_default_value` (which for watts/volts/amps sensors is `0`) back to that default. The result: real production data gets overwritten with fabricated `0` readings every few minutes, visible as sawtooth dropouts in history/energy dashboards. See #696 and #651.

## Fix

Adds `BaseDevice.reset_sensors_when_offline() -> bool` (default `True`, preserving current behavior for every existing device). `EcoFlowDictEntity._handle_coordinator_update` now only resets to default when this returns `True`.

`devices/public/stream_microinverter.py` overrides it to `False`: for this device, "offline" is not a reliable signal of "no data", so holding the last known measurement is more honest than fabricating a `0`.

The reset path also now updates a `deepcopy` of the coordinator's params dict instead of mutating it in place via `jsonpath_ng`'s `.update()`, since the shared dict is read by other entities on the same tick.

## Testing

- Verified against a live STREAM Microinverter on the Public API: `assume_offline`/`offline` transitions no longer zero out `sensor.*_power_ac` and friends; last known value is retained and status entities still correctly report offline/assume_offline.
- `python -m compileall` on all changed files.

## Files

- `custom_components/ecoflow_cloud/devices/__init__.py`
- `custom_components/ecoflow_cloud/entities/__init__.py`
- `custom_components/ecoflow_cloud/devices/public/stream_microinverter.py`