### PR TITLE
feat(config): add per-device "Reset sensors when offline" option

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -15,7 +15,7 @@ from .device_data import DeviceData, DeviceOptions
 _LOGGER = logging.getLogger(__name__)
 
 ECOFLOW_DOMAIN = "ecoflow_cloud"
-CONFIG_VERSION = 12
+CONFIG_VERSION = 13
 
 _PLATFORMS = {
     Platform.BINARY_SENSOR,
@@ -60,9 +60,11 @@ OPTS_POWER_STEP: Final = "power_step"
 OPTS_REFRESH_PERIOD_SEC: Final = "refresh_period_sec"
 OPTS_ASSUME_OFFLINE_SEC: Final = "assume_offline_sec"
 OPTS_VERBOSE_STATUS_MODE: Final = "verbose_status_mode"
+OPTS_RESET_SENSORS_ON_OFFLINE: Final = "reset_sensors_on_offline"
 
 DEFAULT_REFRESH_PERIOD_SEC: Final = 5
 DEFAULT_ASSUME_OFFLINE_SEC: Final = 300  # 5 minutes
+DEFAULT_RESET_SENSORS_ON_OFFLINE: Final = True
 
 _STATUS_COORDINATOR_KEY = "__status_coordinator"
 
@@ -194,6 +196,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         updated = hass.config_entries.async_update_entry(config_entry, version=12)
         _LOGGER.info("Config entries updated to version %d", config_entry.version)
 
+    if config_entry.version == 12:
+        new_options = dict(config_entry.options)
+        for device_options in new_options[CONF_DEVICE_LIST].values():
+            device_options[OPTS_RESET_SENSORS_ON_OFFLINE] = DEFAULT_RESET_SENSORS_ON_OFFLINE
+
+        updated = hass.config_entries.async_update_entry(config_entry, version=13, options=new_options)
+        _LOGGER.info("Config entries updated to version %d", config_entry.version)
+
     return updated
 
 
@@ -210,6 +220,7 @@ def extract_devices(entry: ConfigEntry) -> dict[str, DeviceData]:
                 entry.options[CONF_DEVICE_LIST][sn][OPTS_DIAGNOSTIC_MODE],
                 entry.options[CONF_DEVICE_LIST][sn][OPTS_VERBOSE_STATUS_MODE],
                 entry.options[CONF_DEVICE_LIST][sn][OPTS_ASSUME_OFFLINE_SEC],
+                entry.options[CONF_DEVICE_LIST][sn][OPTS_RESET_SENSORS_ON_OFFLINE],
             ),
             None,
             None,
@@ -265,7 +276,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         api_devices = await api_client.fetch_all_available_devices()
         api_devices_map = {d.sn: d for d in api_devices}
-    except Exception as ex:  # noqa: BLE001
+    except Exception as ex:
         _LOGGER.warning("Failed to fetch device statuses: %s", ex)
         api_devices_map = None
 

--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import (
@@ -33,11 +33,13 @@ from custom_components.ecoflow_cloud import (
     CONFIG_VERSION,
     DEFAULT_ASSUME_OFFLINE_SEC,
     DEFAULT_REFRESH_PERIOD_SEC,
+    DEFAULT_RESET_SENSORS_ON_OFFLINE,
     ECOFLOW_DOMAIN,
     OPTS_ASSUME_OFFLINE_SEC,
     OPTS_DIAGNOSTIC_MODE,
     OPTS_POWER_STEP,
     OPTS_REFRESH_PERIOD_SEC,
+    OPTS_RESET_SENSORS_ON_OFFLINE,
     OPTS_VERBOSE_STATUS_MODE,
     DeviceData,
     DeviceOptions,
@@ -230,7 +232,7 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
             self.new_data[CONF_GROUP],
         )
 
-        errors: Dict[str, str] = {}
+        errors: dict[str, str] = {}
         try:
             await self.auth.login()
         except EcoflowException as e:  # pylint: disable=broad-except
@@ -295,6 +297,7 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
             OPTS_DIAGNOSTIC_MODE: False,
             OPTS_VERBOSE_STATUS_MODE: False,
             OPTS_ASSUME_OFFLINE_SEC: DEFAULT_ASSUME_OFFLINE_SEC,
+            OPTS_RESET_SENSORS_ON_OFFLINE: DEFAULT_RESET_SENSORS_ON_OFFLINE,
         }
 
         return await self.update_or_create()
@@ -331,7 +334,7 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
             self.new_data[CONF_GROUP],
         )
 
-        errors: Dict[str, str] = {}
+        errors: dict[str, str] = {}
         try:
             await self.auth.login()
         except EcoflowException as e:  # pylint: disable=broad-except
@@ -438,6 +441,7 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
             OPTS_DIAGNOSTIC_MODE: ("Diagnostic".lower() == user_input[CONF_DEVICE_TYPE].lower()),
             OPTS_VERBOSE_STATUS_MODE: False,
             OPTS_ASSUME_OFFLINE_SEC: DEFAULT_ASSUME_OFFLINE_SEC,
+            OPTS_RESET_SENSORS_ON_OFFLINE: DEFAULT_RESET_SENSORS_ON_OFFLINE,
         }
 
         return await self.update_or_create()
@@ -459,7 +463,7 @@ class EcoflowOptionsFlow(OptionsFlow):
     def _ensure_devices_loaded(self) -> None:
         if not self.device_selector:
             self.devices = extract_devices(self.config_entry)
-            for _, device in self.devices.items():
+            for device in self.devices.values():
                 self.device_selector[f"{device.name} ({device.sn})"] = device
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
@@ -492,6 +496,10 @@ class EcoflowOptionsFlow(OptionsFlow):
                         vol.Required(OPTS_DIAGNOSTIC_MODE, default=device_options.diagnostic_mode): bool,
                         vol.Required(OPTS_VERBOSE_STATUS_MODE, default=device_options.verbose_status_mode): bool,
                         vol.Required(OPTS_ASSUME_OFFLINE_SEC, default=device_options.assume_offline_sec): int,
+                        vol.Required(
+                            OPTS_RESET_SENSORS_ON_OFFLINE,
+                            default=device_options.reset_sensors_on_offline,
+                        ): bool,
                     }
                 ),
             )
@@ -503,6 +511,7 @@ class EcoflowOptionsFlow(OptionsFlow):
             OPTS_DIAGNOSTIC_MODE: user_input[OPTS_DIAGNOSTIC_MODE],
             OPTS_VERBOSE_STATUS_MODE: user_input[OPTS_VERBOSE_STATUS_MODE],
             OPTS_ASSUME_OFFLINE_SEC: user_input[OPTS_ASSUME_OFFLINE_SEC],
+            OPTS_RESET_SENSORS_ON_OFFLINE: user_input[OPTS_RESET_SENSORS_ON_OFFLINE],
         }
 
         return self.async_create_entry(title="", data=new_options)

--- a/custom_components/ecoflow_cloud/device_data.py
+++ b/custom_components/ecoflow_cloud/device_data.py
@@ -10,6 +10,7 @@ class DeviceOptions:
     diagnostic_mode: bool
     verbose_status_mode: bool
     assume_offline_sec: int
+    reset_sensors_on_offline: bool
 
 
 @dataclasses.dataclass

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -145,7 +145,9 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
     def _handle_coordinator_update(self) -> None:
         if self.coordinator.data.changed:
             self._updated(self.coordinator.data.data_holder.params)
-        elif self._device.status_tracker.is_offline:  # Device is offline  # noqa: SIM102
+        elif (  # noqa: SIM102
+            self._device.status_tracker.is_offline and self._device.device_data.options.reset_sensors_on_offline
+        ):
             # Reset sensors that should reset to default values
             if isinstance(self, BaseSensorEntity) and self._attr_default_value is not None:
                 self._mqtt_key_expr.update(self.coordinator.data.data_holder.params, self._attr_default_value)

--- a/custom_components/ecoflow_cloud/translations/de.json
+++ b/custom_components/ecoflow_cloud/translations/de.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Datenaktualisierungsperiode (Sek.)",
                     "diagnostic_mode": "Diagnosemodus",
                     "assume_offline_sec": "Zeit bis zur Offline-Annahme (Sek.)",
-                    "verbose_status_mode": "Detaillierter Statusmodus"
+                    "verbose_status_mode": "Detaillierter Statusmodus",
+                    "reset_sensors_on_offline": "Sensoren bei Offline-Status zurücksetzen"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/en.json
+++ b/custom_components/ecoflow_cloud/translations/en.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Data refresh period (sec)",
                     "diagnostic_mode": "Diagnostic mode",
                     "assume_offline_sec": "Assume offline timeout (sec)",
-                    "verbose_status_mode": "Verbose status mode"
+                    "verbose_status_mode": "Verbose status mode",
+                    "reset_sensors_on_offline": "Reset sensors when offline"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/fr.json
+++ b/custom_components/ecoflow_cloud/translations/fr.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Période de rafraîchissement des données (sec)",
                     "diagnostic_mode": "Mode diagnostic",
                     "assume_offline_sec": "Délai avant supposition hors ligne (sec)",
-                    "verbose_status_mode": "Mode de statut détaillé"
+                    "verbose_status_mode": "Mode de statut détaillé",
+                    "reset_sensors_on_offline": "Réinitialiser les capteurs hors ligne"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/it.json
+++ b/custom_components/ecoflow_cloud/translations/it.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Periodo di aggiornamento dati (sec)",
                     "diagnostic_mode": "Modalità diagnostica",
                     "assume_offline_sec": "Tempo prima di presumere offline (sec)",
-                    "verbose_status_mode": "Modalità stato dettagliata"
+                    "verbose_status_mode": "Modalità stato dettagliata",
+                    "reset_sensors_on_offline": "Reimposta i sensori quando offline"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/ja.json
+++ b/custom_components/ecoflow_cloud/translations/ja.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "データ更新間隔（秒）",
                     "diagnostic_mode": "診断モード",
                     "assume_offline_sec": "オフラインとみなす待機時間（秒）",
-                    "verbose_status_mode": "ステータス詳細モード"
+                    "verbose_status_mode": "ステータス詳細モード",
+                    "reset_sensors_on_offline": "オフライン時にセンサーをリセット"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/pl.json
+++ b/custom_components/ecoflow_cloud/translations/pl.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Okres odświeżania danych (sek)",
                     "diagnostic_mode": "Tryb diagnostyczny",
                     "assume_offline_sec": "Czas do domniemania offline (sek)",
-                    "verbose_status_mode": "Szczegółowy opis statusu"
+                    "verbose_status_mode": "Szczegółowy opis statusu",
+                    "reset_sensors_on_offline": "Resetuj sensory po przejściu w offline"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/pt-PT.json
+++ b/custom_components/ecoflow_cloud/translations/pt-PT.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Período de atualização de dados (seg.)",
                     "diagnostic_mode": "Modo de diagnóstico",
                     "assume_offline_sec": "Tempo para assumir offline (seg.)",
-                    "verbose_status_mode": "Modo de status detalhado"
+                    "verbose_status_mode": "Modo de status detalhado",
+                    "reset_sensors_on_offline": "Repor sensores quando offline"
                 }
             }
         }

--- a/custom_components/ecoflow_cloud/translations/uk_UA.json
+++ b/custom_components/ecoflow_cloud/translations/uk_UA.json
@@ -70,7 +70,8 @@
                     "refresh_period_sec": "Період оновлення даних (сек)",
                     "diagnostic_mode": "Діагностичний режим",
                     "assume_offline_sec": "Тайм-аут умовного офлайну (сек)",
-                    "verbose_status_mode": "Детальний режим статусу"
+                    "verbose_status_mode": "Детальний режим статусу",
+                    "reset_sensors_on_offline": "Скидати сенсори в офлайні"
                 }
             }
         }

--- a/docs/device_management.md
+++ b/docs/device_management.md
@@ -68,5 +68,8 @@ Use the **Configure** button to adjust specific settings for your devices, such 
     *   Enables the display of the intermediate `assume_offline` status in the Main Status Entity.
     *   If disabled (default), the status will remain `online` during the assume offline timeout, and then switch directly to `offline`.
     *   If enabled, the status will change to `assume_offline` as soon as the initial data timeout is reached.
+*   **Reset sensors when offline**:
+    *   Enabled by default. While the device is offline, sensors that define a default value (most power and current sensors, which default to `0`) are reset to it, so the dashboard does not keep showing stale power readings.
+    *   If disabled, those sensors keep their last received value until new data arrives.
 
 Click **Submit** to save your changes. The integration will reload with the new settings.

--- a/docs/device_status.md
+++ b/docs/device_status.md
@@ -168,6 +168,7 @@ Per device, through the integration's Configure flow:
 |---|---|---|
 | `assume_offline_sec` | 300 | Silence threshold for `ASSUME_OFFLINE`. 3× this (900s) means `OFFLINE`. |
 | `verbose_status_mode` | off | Shows the `assume_offline` label and the extra counters. |
+| `reset_sensors_on_offline` | on | While `OFFLINE`, resets sensors that declare a default value to it. Off keeps the last received value. |
 
 The global coordinator takes the lowest `assume_offline_sec` across all devices
 as its poll cadence, so lowering it on one device speeds up everyone.

--- a/docs/gen.py
+++ b/docs/gen.py
@@ -1,16 +1,16 @@
-from custom_components.ecoflow_cloud.binary_sensor import MiscBinarySensorEntity
 import asyncio
 import json
 import logging
 import os
 import re
-from typing import Any, List
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.frame import async_setup as frame_setup
 
 from custom_components.ecoflow_cloud.api.message import PrivateAPIMessageProtocol
+from custom_components.ecoflow_cloud.binary_sensor import MiscBinarySensorEntity
 from custom_components.ecoflow_cloud.device_data import DeviceData, DeviceOptions
 from custom_components.ecoflow_cloud.devices import BaseDevice, EcoflowDeviceInfo
 from custom_components.ecoflow_cloud.devices.registry import (
@@ -80,7 +80,7 @@ MULTI_DEVICE_CONFIGURATIONS = {
 }
 
 # Initialize configurations
-device_options = DeviceOptions(0, 0, False, False, 600)
+device_options = DeviceOptions(0, 0, False, False, 600, True)
 
 
 class MockSetup:
@@ -103,7 +103,7 @@ class MockSetup:
 class DocumentationGenerator:
     """Handles generation of device documentation."""
 
-    def get_device_data(self, device_type: str) -> List[DeviceData]:
+    def get_device_data(self, device_type: str) -> list[DeviceData]:
         """Get device data for a given device type."""
         if device_type in device_support_sub_devices:
             if device_type in MULTI_DEVICE_CONFIGURATIONS:
@@ -138,7 +138,7 @@ class DocumentationGenerator:
                 )
             ]
 
-    def get_devices(self, hass: HomeAssistant, device_type: str, dev: type[BaseDevice]) -> List[BaseDevice]:
+    def get_devices(self, hass: HomeAssistant, device_type: str, dev: type[BaseDevice]) -> list[BaseDevice]:
         real_devices = []
         device_info = create_test_device_info()
         for device_data in self.get_device_data(device_type):
@@ -147,7 +147,7 @@ class DocumentationGenerator:
             real_devices.append(device)
         return real_devices
 
-    def device_summary(self, base_devices: List[BaseDevice]) -> str:
+    def device_summary(self, base_devices: list[BaseDevice]) -> str:
         """Generate a summary string for devices."""
         if not base_devices:
             return "No devices available"
@@ -193,10 +193,7 @@ class DocumentationGenerator:
                     if len(real_devices) > 1:
                         content = content + f"\n### {device.device_data.device_type}\n"
                     content = content + render_device_summary(device, True)
-                content_summary += "<details><summary> %s <i>(%s)</i> </summary>" % (
-                    dt,
-                    self.device_summary(real_devices),
-                )
+                content_summary += f"<details><summary> {dt} <i>({self.device_summary(real_devices)})</i> </summary>"
                 content_summary += "\n<p>\n"
                 content_summary += content
                 content_summary += "\n</p></details>\n"
@@ -211,10 +208,7 @@ class DocumentationGenerator:
                     if len(real_devices) > 1:
                         content = content + f"\n### {device.device_data.device_type}\n"
                     content = content + render_device_summary(device, True)
-                content_summary += "<details><summary> %s (API) <i>(%s)</i> </summary>" % (
-                    dt,
-                    self.device_summary(real_devices),
-                )
+                content_summary += f"<details><summary> {dt} (API) <i>({self.device_summary(real_devices)})</i> </summary>"
 
                 content_summary += "\n<p>\n"
                 content_summary += content
@@ -267,11 +261,11 @@ class DocumentationGenerator:
 
                 filename = f"{OUTPUT_DIR}/{dt}.md"
                 with open(filename, "w+", encoding="utf-8") as f:
-                    f.write("## %s\n" % dt)
+                    f.write(f"## {dt}\n")
                     f.write(content)
                     f.write("\n\n")
 
-                print("- [%s](devices/%s.md)" % (dt, dt))
+                print(f"- [{dt}](devices/{dt}.md)")
 
         for dt, dev in device_by_product.items():
             if not dt.upper().startswith("DIAGNOSTIC"):
@@ -285,11 +279,11 @@ class DocumentationGenerator:
                 name = dt.replace(" ", "_")
                 filename = f"{OUTPUT_DIR}/{name}-Public.md"
                 with open(filename, "w+", encoding="utf-8") as f:
-                    f.write("## %s\n" % name)
+                    f.write(f"## {name}\n")
                     f.write(content)
                     f.write("\n\n")
 
-                print("- [%s](devices/%s-Public.md)" % (name, name))
+                print(f"- [{name}](devices/{name}-Public.md)")
 
 
 class MarkdownRenderer:
@@ -308,7 +302,7 @@ class MarkdownRenderer:
 
     def prepare_options(self, options: dict[str, Any]) -> str:
         """Prepare options string for display."""
-        return ", ".join(["%s (%s)" % (k, v) for k, v in options.items()])
+        return ", ".join([f"{k} ({v})" for k, v in options.items()])
 
     def prepare_command(self, e: EcoFlowBaseCommandEntity) -> str:
         """Prepare command string for display."""
@@ -319,7 +313,7 @@ class MarkdownRenderer:
             elif isinstance(command_dict, PrivateAPIMessageProtocol):
                 json_dict = command_dict.to_dict()
             else:
-                raise TypeError("Unsupported command_dict type: %s" % type(command_dict).__name__)
+                raise TypeError(f"Unsupported command_dict type: {type(command_dict).__name__}")
 
             # Check if params exist and update marker values
             if "params" in json_dict:
@@ -334,73 +328,69 @@ class MarkdownRenderer:
     def render_sensor(self, sw: BaseSensorEntity, brief: bool = False) -> str:
         """Render sensor entity to markdown."""
         if not isinstance(sw, EcoFlowDictEntity):
-            res = "- %s" % sw.name
+            res = f"- {sw.name}"
         elif brief:
             if sw.enabled_default:
-                res = "- %s" % sw.name
+                res = f"- {sw.name}"
             else:
                 if sw.auto_enable:
-                    res = "- %s  _(auto)_" % sw.name
+                    res = f"- {sw.name}  _(auto)_"
                 else:
-                    res = "- %s  _(disabled)_" % sw.name
+                    res = f"- {sw.name}  _(disabled)_"
         else:
             if sw.enabled_default:
-                res = "- %s (`%s`)" % (sw.name, sw.mqtt_key)
+                res = f"- {sw.name} (`{sw.mqtt_key}`)"
             else:
                 if sw.auto_enable:
-                    res = "- %s (`%s`)   _(auto)_" % (sw.name, sw.mqtt_key)
+                    res = f"- {sw.name} (`{sw.mqtt_key}`)   _(auto)_"
                 else:
-                    res = "- %s (`%s`)   _(disabled)_" % (sw.name, sw.mqtt_key)
+                    res = f"- {sw.name} (`{sw.mqtt_key}`)   _(disabled)_"
 
         # Check for energy sensor on all sensor types
         if hasattr(sw, "energy_sensor"):
-            sw.entity_id = "sensor.%s" % sw._attr_unique_id
+            sw.entity_id = f"sensor.{sw._attr_unique_id}"
             energy_sensor = sw.energy_sensor()
             if energy_sensor is not None:
-                res = res + " (energy:  %s)" % energy_sensor.name
+                res = res + f" (energy:  {energy_sensor.name})"
 
         return res
 
     def render_binary_sensor(self, sw: MiscBinarySensorEntity, brief: bool = False) -> str:
         """Render sensor entity to markdown."""
         if not isinstance(sw, EcoFlowDictEntity):
-            res = "- %s" % sw.name
+            res = f"- {sw.name}"
         elif brief:
             if sw.enabled_default:
-                res = "- %s" % sw.name
+                res = f"- {sw.name}"
             else:
                 if sw.auto_enable:
-                    res = "- %s  _(auto)_" % sw.name
+                    res = f"- {sw.name}  _(auto)_"
                 else:
-                    res = "- %s  _(disabled)_" % sw.name
+                    res = f"- {sw.name}  _(disabled)_"
         else:
             if sw.enabled_default:
-                res = "- %s (`%s`)" % (sw.name, sw.mqtt_key)
+                res = f"- {sw.name} (`{sw.mqtt_key}`)"
             else:
                 if sw.auto_enable:
-                    res = "- %s (`%s`)   _(auto)_" % (sw.name, sw.mqtt_key)
+                    res = f"- {sw.name} (`{sw.mqtt_key}`)   _(auto)_"
                 else:
-                    res = "- %s (`%s`)   _(disabled)_" % (sw.name, sw.mqtt_key)
+                    res = f"- {sw.name} (`{sw.mqtt_key}`)   _(disabled)_"
 
         return res
 
     def render_switch(self, sw: BaseSwitchEntity, brief: bool = False) -> str:
         """Render switch entity to markdown."""
         if brief:
-            return "- %s%s" % (sw.name, self.command_ro(sw))
+            return f"- {sw.name}{self.command_ro(sw)}"
         else:
-            return "- %s (`%s` -> `%s`)" % (
-                sw.name,
-                sw.mqtt_key,
-                self.prepare_command(sw),
-            )
+            return f"- {sw.name} (`{sw.mqtt_key}` -> `{self.prepare_command(sw)}`)"
 
     def render_number(self, sw: BaseNumberEntity, brief: bool = False) -> str:
         """Render number entity to markdown."""
         if brief:
-            return "- %s%s" % (sw.name, self.command_ro(sw))
+            return f"- {sw.name}{self.command_ro(sw)}"
         else:
-            return "- %s (`%s` -> `%s` [%d - %d])" % (
+            return "- %s (`%s` -> `%s` [%d - %d])" % (  # noqa: UP031
                 sw.name,
                 sw.mqtt_key,
                 self.prepare_command(sw),
@@ -411,9 +401,9 @@ class MarkdownRenderer:
     def render_select(self, sw: BaseSelectEntity, brief: bool = False) -> str:
         """Render select entity to markdown."""
         if brief:
-            return "- %s%s" % (sw.name, self.command_ro(sw))
+            return f"- {sw.name}{self.command_ro(sw)}"
         else:
-            return "- %s (`%s` -> `%s` [%s])" % (
+            return "- %s (`%s` -> `%s` [%s])" % (  # noqa: UP031
                 sw.name,
                 sw.mqtt_key,
                 self.prepare_command(sw),


### PR DESCRIPTION
Sensors that declare a default value were unconditionally reset to it while the device was offline. Make that behaviour opt-out per device via a new `reset_sensors_on_offline` option, defaulting to on so existing setups keep the current behaviour.

Bumps CONFIG_VERSION to 13 and seeds the key on existing entries, since extract_devices reads the options dict by direct indexing.

Also includes a ruff modernization pass over docs/gen.py (%-format to f-strings, typing.List/Dict to builtins).