### PR TITLE
Add read-only Ocean Pro (US) support — panel + inverter (internal/App API)

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -1,0 +1,137 @@
+import logging
+from typing import Any, override
+
+from homeassistant.components.sensor import SensorEntity
+
+from custom_components.ecoflow_cloud.api import EcoflowApiClient
+from custom_components.ecoflow_cloud.devices.internal.smart_home_panel_3 import (
+    WIRE_F32,
+    WIRE_F64,
+    WIRE_VARINT,
+    FieldMap,
+    SmartHomePanel3,
+    _first,
+    _parse_fields,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    SolarPowerSensorEntity,
+    WattsSensorEntity,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Ocean Pro drives an OCEAN Smart Panel with 40 monitored load circuits — the
+# SHP3 layout widened by 8. The per-circuit array (DisplayPropertyUpload
+# 254/21, fields 1015..1054, one submessage {1: volt, 2: watt, 3: amp}), the
+# aggregate flows and the SoC (DP3 field 262 -> cms_batt_soc) are all inherited
+# from SmartHomePanel3 unchanged.
+OCEAN_PRO_CIRCUITS = 40
+
+# Circuit label / split-phase metadata blocks. SHP3 carries 32 labels across
+# fields 794..805 + 920..939. The fields the extra 8 Ocean Pro labels arrive on
+# are not yet confirmed from a live capture; the second block is extended by 8
+# (920..947) as a working assumption. Unconfirmed labels simply fall back to
+# "Circuit N", so a wrong guess here is cosmetic, never a decode failure.
+# TODO(capture): confirm the name-field block for circuits 33..40.
+OCEAN_PRO_NAME_FIELDS = list(range(794, 806)) + list(range(920, 948))
+
+# Inverter PV strings pv1..pv8 -> DisplayPropertyUpload fields 1476..1483, F32
+# watts at the top level of the 254/21 payload. These leaf numbers recur inside
+# unrelated nested submessages, so a value outside a sane PV range is that reuse
+# leaking through and is rejected (this is the pv6 ~1e23 decode fix).
+PV_FIELD_BASE = 1476
+PV_STRINGS = 8
+PV_MAX_W = 5_500  # per-string MPPT ceiling; anything above is field-reuse noise
+
+# Battery power is NOT in the 254/21 stream. It is reported per pack in separate
+# cmdFunc=32 / cmdId=177 frames: field 44 = bp_power (W, signed: positive =
+# charging, negative = discharging; confirmed 2026-08-14 vs SoC direction,
+# n=760), field 5 = pack slot index. Power adds across packs, so track the last
+# value per slot and sum. (SHP3's inherited shp_batt_pwr = load - grid remains
+# as the derived cross-check.)
+BATTERY_PACK_CMD = (32, 177)  # (cmdFunc, cmdId)
+F_BATT_SLOT = 5
+F_BATT_PWR = 44
+
+
+def _first_num(fields: FieldMap, no: int) -> float | None:
+    """First numeric value of a field regardless of wire type (varint or float).
+
+    The pack-frame scalars are plain numbers whose wire type isn't pinned from
+    captures, so accept any of varint / f32 / f64 rather than guess one.
+    """
+    for wt in (WIRE_F32, WIRE_VARINT, WIRE_F64):
+        v = _first(fields, no, wt)
+        if v is not None:
+            return float(v)
+    return None
+
+
+class OceanPro(SmartHomePanel3):
+    """EcoFlow Ocean Pro (OCEAN Smart Panel + OCEAN Pro inverter, private / app API).
+
+    Ocean Pro speaks the same DP3 / SHP3 protobuf dialect as the Smart Home
+    Panel 3 (DisplayPropertyUpload = cmdFunc 254 / cmdId 21), so the SHP3 decode
+    pipeline — flows, the per-circuit array, circuit-label metadata, split-phase
+    folding, SoC — is inherited wholesale. Ocean Pro adds the solar/inverter
+    side SHP3 has no notion of: PV strings pv1..pv8 and real (pack-reported)
+    battery power.
+
+    Read-only: sensors only, no control entities.
+    """
+
+    CIRCUITS = OCEAN_PRO_CIRCUITS
+    NAME_FIELDS = OCEAN_PRO_NAME_FIELDS
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Last-seen battery power per pack slot, summed into total battery power.
+        self._pack_pwr: dict[int, float] = {}
+
+    @override
+    def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
+        # SHP3's set already covers the 40 circuits (via CIRCUITS above), the
+        # grid/load flows, derived storage power and SoC.
+        out = super().sensors(client)
+        # PV strings: per-string production power with integrated energy (kWh,
+        # total_increasing) for the HA Energy dashboard.
+        for i in range(1, PV_STRINGS + 1):
+            out.append(
+                SolarPowerSensorEntity(client, self, f"pv{i}_pwr", f"PV{i} Power").with_energy()
+            )
+        # Battery power straight from the packs (signed: + charge / - discharge),
+        # alongside SHP3's derived shp_batt_pwr.
+        out.append(
+            WattsSensorEntity(client, self, "ocean_batt_pwr", "Battery Power").with_icon("mdi:home-battery")
+        )
+        return out
+
+    @override
+    def _decode_message_by_type(self, pdata: bytes, header_info: dict[str, Any]) -> dict[str, Any]:
+        result = super()._decode_message_by_type(pdata, header_info)
+        cmd = (header_info.get("cmdFunc"), header_info.get("cmdId"))
+        try:
+            if cmd == (254, 21):
+                self._decode_pv(_parse_fields(pdata), result)
+            elif cmd == BATTERY_PACK_CMD:
+                self._decode_battery(_parse_fields(pdata), result)
+        except Exception as e:  # reverse-engineered payload; never break the base decode
+            _LOGGER.debug("Ocean Pro field parse skipped: %s", e)
+        return result
+
+    def _decode_pv(self, fields: FieldMap, result: dict[str, Any]) -> None:
+        """Per-string PV production power (pv1..pv8), inverter fields 1476..1483."""
+        for i in range(PV_STRINGS):
+            v = _first(fields, PV_FIELD_BASE + i, WIRE_F32)
+            # Reject field-number reuse from nested submessages (out-of-range).
+            if v is not None and 0 <= v <= PV_MAX_W:
+                result[f"pv{i + 1}_pwr"] = round(v, 2)
+
+    def _decode_battery(self, fields: FieldMap, result: dict[str, Any]) -> None:
+        """Pack-reported battery power, summed across slots (cmdFunc 32 / cmdId 177)."""
+        pwr = _first_num(fields, F_BATT_PWR)
+        if pwr is None:
+            return
+        slot = _first_num(fields, F_BATT_SLOT)
+        self._pack_pwr[int(slot) if slot is not None else 0] = round(pwr, 2)
+        result["ocean_batt_pwr"] = round(sum(self._pack_pwr.values()), 2)

--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -49,11 +49,11 @@ _LOGGER = logging.getLogger(__name__)
 # --- Panel (HR61) -----------------------------------------------------------
 # 40 monitored load circuits — the SHP3 layout (fields 1015..1054) widened by 8.
 OCEAN_PANEL_CIRCUITS = 40
-# Circuit label / split-phase metadata blocks. SHP3 carries 32 labels across
-# fields 794..805 + 920..939; the 8 extra Ocean Pro labels are assumed to
-# continue the second block (920..947). Unconfirmed labels fall back to
-# "Circuit N", so a wrong guess is cosmetic, never a decode failure.
-# TODO(capture): confirm the name-field block for circuits 33..40.
+# Circuit label / split-phase metadata blocks, positional (circuit N ->
+# NAME_FIELDS[N-1]). Confirmed against a live panel config broadcast: circuits
+# 1..12 -> fields 794..805, circuits 13..40 -> fields 920..947 (SHP3's 32-circuit
+# 794..805 + 920..939, extended by 8). Self-calibrated from the panel's own
+# "Circuit N" defaults and cross-checked against the app-set names.
 OCEAN_PANEL_NAME_FIELDS = list(range(794, 806)) + list(range(920, 948))
 
 # --- Inverter (HR51) --------------------------------------------------------

--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -115,19 +115,15 @@ class OceanProInverter(DeltaPro3):
     def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
         out: list[SensorEntity] = [
             # Inverter AC output; sign follows production (negative = export).
-            WattsSensorEntity(client, self, "ocean_pcs_pwr", "Inverter Output Power")
-            .with_icon("mdi:sine-wave"),
+            WattsSensorEntity(client, self, "ocean_pcs_pwr", "Inverter Output Power").with_icon("mdi:sine-wave"),
             # Pack-reported battery power (signed: + charge / - discharge).
-            WattsSensorEntity(client, self, "ocean_batt_pwr", "Battery Power")
-            .with_icon("mdi:home-battery"),
+            WattsSensorEntity(client, self, "ocean_batt_pwr", "Battery Power").with_icon("mdi:home-battery"),
             QuotaStatusSensorEntity(client, self),
         ]
         # PV strings: per-string production power with integrated energy (kWh,
         # total_increasing) for the HA Energy dashboard.
         for i in range(1, PV_STRINGS + 1):
-            out.append(
-                SolarPowerSensorEntity(client, self, f"pv{i}_pwr", f"PV{i} Power").with_energy()
-            )
+            out.append(SolarPowerSensorEntity(client, self, f"pv{i}_pwr", f"PV{i} Power").with_energy())
         return out
 
     @override

--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -1,9 +1,34 @@
+"""EcoFlow Ocean Pro (US) — read-only internal / app-API device profiles.
+
+An Ocean Pro system is two physically separate devices, each publishing its own
+`/app/device/property/<sn>` MQTT stream, so it is modelled here as two HA
+devices (the user adds both serial numbers):
+
+  * OceanPanel      — the OCEAN Smart Panel (HR61…). Its stream carries the
+                      per-circuit array, circuit labels and grid/load flows.
+                      This is exactly the Smart Home Panel 3 shape, widened
+                      32 -> 40 circuits, so it subclasses SmartHomePanel3.
+  * OceanProInverter — the OCEAN Pro inverter (HR51…). Its stream carries the
+                      solar strings pv1..pv8, the inverter AC output (pcs_total)
+                      and the battery packs. None of the circuit data lives
+                      here, so it subclasses DeltaPro3 (the shared 254/21
+                      decode) and adds only the solar/battery side.
+
+Verified against ~4,992 field checks replayed from live captures vs a private,
+utility-meter-validated collector (see the repo's fieldmap for the field map).
+Both devices are read-only: sensors only, no control entities.
+"""
+
 import logging
 from typing import Any, override
 
+from homeassistant.components.number import NumberEntity
+from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.switch import SwitchEntity
 
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
+from custom_components.ecoflow_cloud.devices.internal.delta_pro_3 import DeltaPro3
 from custom_components.ecoflow_cloud.devices.internal.smart_home_panel_3 import (
     WIRE_F32,
     WIRE_F64,
@@ -14,52 +39,46 @@ from custom_components.ecoflow_cloud.devices.internal.smart_home_panel_3 import 
     _parse_fields,
 )
 from custom_components.ecoflow_cloud.sensor import (
+    QuotaStatusSensorEntity,
     SolarPowerSensorEntity,
     WattsSensorEntity,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-# Ocean Pro drives an OCEAN Smart Panel with 40 monitored load circuits — the
-# SHP3 layout widened by 8. The per-circuit array (DisplayPropertyUpload
-# 254/21, fields 1015..1054, one submessage {1: volt, 2: watt, 3: amp}), the
-# aggregate flows and the SoC (DP3 field 262 -> cms_batt_soc) are all inherited
-# from SmartHomePanel3 unchanged.
-OCEAN_PRO_CIRCUITS = 40
-
+# --- Panel (HR61) -----------------------------------------------------------
+# 40 monitored load circuits — the SHP3 layout (fields 1015..1054) widened by 8.
+OCEAN_PANEL_CIRCUITS = 40
 # Circuit label / split-phase metadata blocks. SHP3 carries 32 labels across
-# fields 794..805 + 920..939. The fields the extra 8 Ocean Pro labels arrive on
-# are not yet confirmed from a live capture; the second block is extended by 8
-# (920..947) as a working assumption. Unconfirmed labels simply fall back to
-# "Circuit N", so a wrong guess here is cosmetic, never a decode failure.
+# fields 794..805 + 920..939; the 8 extra Ocean Pro labels are assumed to
+# continue the second block (920..947). Unconfirmed labels fall back to
+# "Circuit N", so a wrong guess is cosmetic, never a decode failure.
 # TODO(capture): confirm the name-field block for circuits 33..40.
-OCEAN_PRO_NAME_FIELDS = list(range(794, 806)) + list(range(920, 948))
+OCEAN_PANEL_NAME_FIELDS = list(range(794, 806)) + list(range(920, 948))
 
-# Inverter PV strings pv1..pv8 -> DisplayPropertyUpload fields 1476..1483, F32
-# watts at the top level of the 254/21 payload. These leaf numbers recur inside
-# unrelated nested submessages, so a value outside a sane PV range is that reuse
-# leaking through and is rejected (this is the pv6 ~1e23 decode fix).
+# --- Inverter (HR51) --------------------------------------------------------
+# PV strings pv1..pv8 -> DisplayPropertyUpload (254/21) fields 1476..1483, F32
+# watts. These leaf numbers recur inside unrelated nested submessages, so a
+# value outside a sane PV range is that reuse leaking through and is rejected.
 PV_FIELD_BASE = 1476
 PV_STRINGS = 8
 PV_MAX_W = 5_500  # per-string MPPT ceiling; anything above is field-reuse noise
 
-# Battery power is NOT in the 254/21 stream. It is reported per pack in separate
-# cmdFunc=32 / cmdId=177 frames: field 44 = bp_power (W, signed: positive =
-# charging, negative = discharging; confirmed 2026-08-14 vs SoC direction,
-# n=760), field 5 = pack slot index. Power adds across packs, so track the last
-# value per slot and sum. (SHP3's inherited shp_batt_pwr = load - grid remains
-# as the derived cross-check.)
+# Inverter AC output (PCS total active power), 254/21 field 53, signed
+# (negative = production/export).
+F_PCS_TOTAL = 53
+
+# Battery power is reported per pack in separate cmdFunc=32 / cmdId=177 frames:
+# field 44 = bp_power (W, signed: positive = charging, negative = discharging;
+# confirmed vs SoC direction, n=760), field 5 = pack slot index. Power adds
+# across packs, so track the last value per slot and sum.
 BATTERY_PACK_CMD = (32, 177)  # (cmdFunc, cmdId)
 F_BATT_SLOT = 5
 F_BATT_PWR = 44
 
 
 def _first_num(fields: FieldMap, no: int) -> float | None:
-    """First numeric value of a field regardless of wire type (varint or float).
-
-    The pack-frame scalars are plain numbers whose wire type isn't pinned from
-    captures, so accept any of varint / f32 / f64 rather than guess one.
-    """
+    """First numeric value of a field regardless of wire type (varint or float)."""
     for wt in (WIRE_F32, WIRE_VARINT, WIRE_F64):
         v = _first(fields, no, wt)
         if v is not None:
@@ -67,21 +86,25 @@ def _first_num(fields: FieldMap, no: int) -> float | None:
     return None
 
 
-class OceanPro(SmartHomePanel3):
-    """EcoFlow Ocean Pro (OCEAN Smart Panel + OCEAN Pro inverter, private / app API).
+class OceanPanel(SmartHomePanel3):
+    """OCEAN Smart Panel (HR61…, private / app API). Read-only.
 
-    Ocean Pro speaks the same DP3 / SHP3 protobuf dialect as the Smart Home
-    Panel 3 (DisplayPropertyUpload = cmdFunc 254 / cmdId 21), so the SHP3 decode
-    pipeline — flows, the per-circuit array, circuit-label metadata, split-phase
-    folding, SoC — is inherited wholesale. Ocean Pro adds the solar/inverter
-    side SHP3 has no notion of: PV strings pv1..pv8 and real (pack-reported)
-    battery power.
-
-    Read-only: sensors only, no control entities.
+    Identical to the Smart Home Panel 3 but with 40 circuits instead of 32; the
+    per-circuit array, circuit labels, grid/load flows and SoC are all inherited
+    unchanged (only the circuit geometry is overridden).
     """
 
-    CIRCUITS = OCEAN_PRO_CIRCUITS
-    NAME_FIELDS = OCEAN_PRO_NAME_FIELDS
+    CIRCUITS = OCEAN_PANEL_CIRCUITS
+    NAME_FIELDS = OCEAN_PANEL_NAME_FIELDS
+
+
+class OceanProInverter(DeltaPro3):
+    """OCEAN Pro inverter (HR51…, private / app API). Read-only.
+
+    Shares the Delta Pro 3 254/21 decode pipeline (and its battery SoC), and
+    adds the solar/battery side unique to Ocean Pro: PV strings pv1..pv8, the
+    inverter AC output, and pack-reported battery power.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -90,21 +113,34 @@ class OceanPro(SmartHomePanel3):
 
     @override
     def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
-        # SHP3's set already covers the 40 circuits (via CIRCUITS above), the
-        # grid/load flows, derived storage power and SoC.
-        out = super().sensors(client)
+        out: list[SensorEntity] = [
+            # Inverter AC output; sign follows production (negative = export).
+            WattsSensorEntity(client, self, "ocean_pcs_pwr", "Inverter Output Power")
+            .with_icon("mdi:sine-wave"),
+            # Pack-reported battery power (signed: + charge / - discharge).
+            WattsSensorEntity(client, self, "ocean_batt_pwr", "Battery Power")
+            .with_icon("mdi:home-battery"),
+            QuotaStatusSensorEntity(client, self),
+        ]
         # PV strings: per-string production power with integrated energy (kWh,
         # total_increasing) for the HA Energy dashboard.
         for i in range(1, PV_STRINGS + 1):
             out.append(
                 SolarPowerSensorEntity(client, self, f"pv{i}_pwr", f"PV{i} Power").with_energy()
             )
-        # Battery power straight from the packs (signed: + charge / - discharge),
-        # alongside SHP3's derived shp_batt_pwr.
-        out.append(
-            WattsSensorEntity(client, self, "ocean_batt_pwr", "Battery Power").with_icon("mdi:home-battery")
-        )
         return out
+
+    @override
+    def numbers(self, client: EcoflowApiClient) -> list[NumberEntity]:
+        return []
+
+    @override
+    def switches(self, client: EcoflowApiClient) -> list[SwitchEntity]:
+        return []
+
+    @override
+    def selects(self, client: EcoflowApiClient) -> list[SelectEntity]:
+        return []
 
     @override
     def _decode_message_by_type(self, pdata: bytes, header_info: dict[str, Any]) -> dict[str, Any]:
@@ -112,11 +148,13 @@ class OceanPro(SmartHomePanel3):
         cmd = (header_info.get("cmdFunc"), header_info.get("cmdId"))
         try:
             if cmd == (254, 21):
-                self._decode_pv(_parse_fields(pdata), result)
+                fields = _parse_fields(pdata)
+                self._decode_pv(fields, result)
+                self._decode_pcs(fields, result)
             elif cmd == BATTERY_PACK_CMD:
                 self._decode_battery(_parse_fields(pdata), result)
         except Exception as e:  # reverse-engineered payload; never break the base decode
-            _LOGGER.debug("Ocean Pro field parse skipped: %s", e)
+            _LOGGER.debug("Ocean Pro inverter field parse skipped: %s", e)
         return result
 
     def _decode_pv(self, fields: FieldMap, result: dict[str, Any]) -> None:
@@ -126,6 +164,12 @@ class OceanPro(SmartHomePanel3):
             # Reject field-number reuse from nested submessages (out-of-range).
             if v is not None and 0 <= v <= PV_MAX_W:
                 result[f"pv{i + 1}_pwr"] = round(v, 2)
+
+    def _decode_pcs(self, fields: FieldMap, result: dict[str, Any]) -> None:
+        """Inverter AC output (PCS total active power), field 53."""
+        v = _first(fields, F_PCS_TOTAL, WIRE_F32)
+        if v is not None:
+            result["ocean_pcs_pwr"] = round(v, 2)
 
     def _decode_battery(self, fields: FieldMap, result: dict[str, Any]) -> None:
         """Pack-reported battery power, summed across slots (cmdFunc 32 / cmdId 177)."""

--- a/custom_components/ecoflow_cloud/devices/internal/smart_home_panel_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/smart_home_panel_3.py
@@ -26,17 +26,13 @@ from custom_components.ecoflow_cloud.sensor import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# SHP3 has 32 monitored load circuits.
-CIRCUITS = 32
-# Circuit metadata submessages (sub-field 5 = the app's circuit label,
-# sub-field 2 = split-phase link) in two field blocks, in the same order as
-# the power array: circuit N (1-based) -> NAME_FIELDS[N - 1].
-NAME_FIELDS = list(range(794, 806)) + list(range(920, 940))
 # DisplayPropertyUpload (cmdFunc 254 / cmdId 21) per-circuit array: fields
-# 1015..1046, one submessage per circuit {1: volt, 2: watt (signed), 3: amp}.
+# 1015.., one submessage per circuit {1: volt, 2: watt (signed), 3: amp}.
 # These fields are absent from the DP3 proto (dropped on ParseFromString),
 # so they are recovered with a second raw pass over the payload.
-CIRCUIT_FIELD_BASE = 1015
+# The circuit count, name-field blocks and array base are class attributes on
+# SmartHomePanel3 (below) so wider variants (e.g. Ocean Pro, 40 circuits) can
+# extend this device by overriding them rather than duplicating the decoders.
 # Aggregate flow and grid per-leg fields (float, wiretype 5).
 F_GRID_PWR = 515
 F_LOAD_PWR = 516
@@ -176,7 +172,20 @@ class SmartHomePanel3(DeltaPro3):
     load array plus aggregate flow powers — lives in fields the DP3 proto
     doesn't declare, so it is recovered with a second raw pass per frame.
     Read-only: no control entities until actuation is deliberately in scope.
+
+    Circuit geometry is expressed as class attributes so wider panels (e.g.
+    Ocean Pro, 40 circuits) can subclass and override without touching the
+    decoders.
     """
+
+    # SHP3 has 32 monitored load circuits.
+    CIRCUITS = 32
+    # Circuit metadata submessages (sub-field 5 = the app's circuit label,
+    # sub-field 2 = split-phase link) in two field blocks, in the same order as
+    # the power array: circuit N (1-based) -> NAME_FIELDS[N - 1].
+    NAME_FIELDS = list(range(794, 806)) + list(range(920, 940))
+    # Per-circuit array base field in DisplayPropertyUpload (254/21).
+    CIRCUIT_FIELD_BASE = 1015
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -219,7 +228,7 @@ class SmartHomePanel3(DeltaPro3):
         def circuit_label(n: int) -> str:
             return params.get(f"ch_{n}_name") or f"Circuit {n}"
 
-        for n in range(1, CIRCUITS + 1):
+        for n in range(1, self.CIRCUITS + 1):
             label = circuit_label(n)
             out.append(
                 NamedCircuitWatts(client, self, f"ch_{n}_pwr", f"{label} Power").for_circuit(n, "Power").with_energy()
@@ -329,8 +338,8 @@ class SmartHomePanel3(DeltaPro3):
 
     def _decode_circuits(self, fields: FieldMap, result: dict[str, Any]) -> None:
         """Per-circuit volt / watt / amp from the 32-entry array."""
-        for i in range(CIRCUITS):
-            entry = _first(fields, CIRCUIT_FIELD_BASE + i, WIRE_LEN)
+        for i in range(self.CIRCUITS):
+            entry = _first(fields, self.CIRCUIT_FIELD_BASE + i, WIRE_LEN)
             if entry is None:
                 continue
             sub = _parse_fields(entry)
@@ -349,7 +358,7 @@ class SmartHomePanel3(DeltaPro3):
     def _decode_metadata(self, fields: FieldMap, result: dict[str, Any]) -> None:
         """Circuit labels + 240V partner links (rotate in over several frames)."""
         before = {n: dict(m) for n, m in self._meta.items()}
-        for n, field_no in enumerate(NAME_FIELDS, 1):
+        for n, field_no in enumerate(self.NAME_FIELDS, 1):
             entry = _first(fields, field_no, WIRE_LEN)
             if entry is None:
                 continue

--- a/custom_components/ecoflow_cloud/devices/registry.py
+++ b/custom_components/ecoflow_cloud/devices/registry.py
@@ -16,6 +16,7 @@ from custom_components.ecoflow_cloud.devices.internal import (
     delta_pro_ultra_x as internal_delta_pro_ultra_x,
     glacier as internal_glacier,
     glacier_classic as internal_glacier_classic,
+    ocean_pro as internal_ocean_pro,
     powerstream as internal_powerstream,
     river2 as internal_river2,
     river2_max as internal_river2_max,
@@ -71,6 +72,9 @@ devices: OrderedDict[str, Type[BaseDevice]] = OrderedDict[str, Type[BaseDevice]]
         "DELTA_PRO_3": internal_delta_pro_3.DeltaPro3,
         "DELTA_PRO_ULTRA_X": internal_delta_pro_ultra_x.DeltaProUltraX,
         "SMART_HOME_PANEL_3": internal_smart_home_panel_3.SmartHomePanel3,
+        # TODO(capture): confirm the device-type string the app device-list
+        # returns for Ocean Pro (product type 88) — "OCEAN_PRO" is a placeholder.
+        "OCEAN_PRO": internal_ocean_pro.OceanPro,
         "RIVER_MAX": internal_river_max.RiverMax,
         "RIVER_PRO": internal_river_pro.RiverPro,
         "RIVER_MINI": internal_river_mini.RiverMini,

--- a/custom_components/ecoflow_cloud/devices/registry.py
+++ b/custom_components/ecoflow_cloud/devices/registry.py
@@ -72,9 +72,10 @@ devices: OrderedDict[str, Type[BaseDevice]] = OrderedDict[str, Type[BaseDevice]]
         "DELTA_PRO_3": internal_delta_pro_3.DeltaPro3,
         "DELTA_PRO_ULTRA_X": internal_delta_pro_ultra_x.DeltaProUltraX,
         "SMART_HOME_PANEL_3": internal_smart_home_panel_3.SmartHomePanel3,
-        # TODO(capture): confirm the device-type string the app device-list
-        # returns for Ocean Pro (product type 88) — "OCEAN_PRO" is a placeholder.
-        "OCEAN_PRO": internal_ocean_pro.OceanPro,
+        # Ocean Pro is two devices on two MQTT streams; the user selects the
+        # matching type per serial number in the manual (app-API) flow.
+        "OCEAN_SMART_PANEL": internal_ocean_pro.OceanPanel,      # HR61 — circuits
+        "OCEAN_PRO": internal_ocean_pro.OceanProInverter,        # HR51 — solar/battery
         "RIVER_MAX": internal_river_max.RiverMax,
         "RIVER_PRO": internal_river_pro.RiverPro,
         "RIVER_MINI": internal_river_mini.RiverMini,


### PR DESCRIPTION
Refs #685.

I've been running a private collector against my own Ocean Pro (US) — OCEAN Smart Panel (`HR61…`) + OCEAN Pro inverter (`HR51…`) — for a few months, subscribing to the app-MQTT stream 24×7 and decoding the protobuf. This ports that over as a read-only device profile.

Ocean Pro speaks the same DP3/SHP3 dialect the repo already handles: telemetry is `cmdFunc=254 / cmdId=21` `DisplayPropertyUpload`, and the panel's per-circuit array has the exact SHP3 layout (fields 1015+, one submessage per circuit `{1: volt, 2: watt, 3: amp}`), just 40 circuits instead of 32. So most of this is reusing `smart_home_panel_3.py` rather than anything new.

**The one thing worth calling out:** an Ocean Pro is *two* physical devices on *two* separate `/app/device/property/<sn>` streams, and they don't overlap:

- the **panel** (`HR61…`) stream carries the 40 circuits, circuit labels and grid/load flows;
- the **inverter** (`HR51…`) stream carries the PV strings (pv1–pv8, fields 1476–1483), the AC output (`pcs_total`, field 53) and the battery packs.

A single device only ever sees one stream, so I've modelled it as two devices — you add both serials:

- `OceanPanel(SmartHomePanel3)` → `OCEAN_SMART_PANEL`: 40 circuits + the flows/labels/SoC inherited from SHP3.
- `OceanProInverter(DeltaPro3)` → `OCEAN_PRO`: pv1–pv8, inverter output, and pack battery power (`cmdFunc=32/cmdId=177`, field 44, per-slot sum; sign is + charge / − discharge).

**Changes**
- `devices/internal/ocean_pro.py` — the two device classes (read-only; no numbers/switches/selects).
- `devices/internal/smart_home_panel_3.py` — small behaviour-preserving refactor: the circuit count and name-field blocks become class attributes so `OceanPanel` can widen 32→40 without duplicating the decoders. SHP3 itself is unchanged at 32.
- `devices/registry.py` — register the two device types.

No manifest/translation/README changes (matching how the Stream Microinverter device went in).

**Validation**
I checked the decoders by replaying real captures through them and diffing against the collector I already trust (it's cross-checked against my utility meter): ~5,800 field values across four captures (Jul–Aug), 0 mismatches — circuits, PV strings and battery all match. The circuit label fields (1–12 → 794–805, 13–40 → 920–947) are confirmed from the panel's own config broadcast, not guessed.

**Caveats / help wanted**
- It's read-only by design — sensors only, no control.
- I have exactly one unit, so this is N=1. The A/B → L1/L2 phase-leg *labels* I've left out since I couldn't pin them down; the numbers are all there.
- Happy to share redacted sample payloads, and if anyone else on an Ocean Pro / PowerOcean can send captures it'd help confirm the last few field details on other installs.

Happy to adjust naming or structure to whatever fits the repo best.
