### PR TITLE
fix(ocean-pro): reject implausible battery-power spikes

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -75,6 +75,12 @@ F_PCS_TOTAL = 53
 BATTERY_PACK_CMD = (32, 177)  # (cmdFunc, cmdId)
 F_BATT_SLOT = 5
 F_BATT_PWR = 44
+# field 44 usually carries a sane per-pack power (watts), but intermittently
+# emits an implausible spike (tens to hundreds of kW for a single pack) that the
+# per-slot sum then amplifies. Reject any read beyond a pack's realistic share of
+# the inverter's rating (~24 kW / 4 packs, with generous headroom) as decode
+# noise, and keep the slot's last good value — same guard used for PV strings.
+BATT_PACK_MAX_W = 10_000
 
 
 def _first_num(fields: FieldMap, no: int) -> float | None:
@@ -170,7 +176,9 @@ class OceanProInverter(DeltaPro3):
     def _decode_battery(self, fields: FieldMap, result: dict[str, Any]) -> None:
         """Pack-reported battery power, summed across slots (cmdFunc 32 / cmdId 177)."""
         pwr = _first_num(fields, F_BATT_PWR)
-        if pwr is None:
+        # Missing, or an implausible spike (field-44 decode noise) — keep the
+        # last good per-slot values rather than poisoning the sum.
+        if pwr is None or abs(pwr) > BATT_PACK_MAX_W:
             return
         slot = _first_num(fields, F_BATT_SLOT)
         self._pack_pwr[int(slot) if slot is not None else 0] = round(pwr, 2)


### PR DESCRIPTION
Follow-up to #892 — a fix I found once I connected it to a live device.

The Ocean Pro inverter's per-pack battery power (`cmdFunc=32/cmdId=177`, field 44) is usually a sane watt-level value, but it intermittently throws an implausible spike — tens to hundreds of kW for a single pack — and the per-slot sum turns that into a wildly wrong **Battery Power** reading (I was seeing −55 kW+ on a system whose inverter is 24 kW).

Watching a live connection, the raw field swings between sane (a few W at ~100 % SoC) and spikes of −3 kW to −18 kW per pack. This clamps each pack's reading to a plausible bound (a pack's share of the 24 kW inverter, with headroom) and keeps the slot's last good value on an out-of-range read — the same guard the PV strings already use. After the clamp the sensor tracks the real idle draw (tens of W) and genuine transients (a few kW) and drops the garbage.

Worth noting for anyone reviewing: this only showed up under a live connection. My original validation replayed captured frames and missed it, because it was comparing the decoder against another reader of the same flaky field. The other Ocean Pro sensors (PV strings, inverter output, the 40 circuits, SoC, pack voltage/capacity) all check out live.
