### PR TITLE
fix: auto_enable never actually enabled a first-time entity

### DIFF
--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -106,6 +106,20 @@ class EcoFlowDictEntity(EcoFlowAbstractDataEntity):
         self._multiple_value_sum = False
 
         self._auto_enable = auto_enable
+        if auto_enable and not enabled:
+            # auto_enable is meant to let whichever key variant actually
+            # reports data win, by flipping enabled_default once _updated()
+            # sees a value. But HA decides whether a *new* registry entry
+            # starts enabled/visible at the moment this entity is first
+            # added to hass - which happens synchronously, before any
+            # coordinator update (and therefore before _updated() could ever
+            # have run) can occur. So on a real first-time setup, that flip
+            # always came too late and the entity always started hidden and
+            # disabled, regardless of auto_enable. quota_all() already
+            # populated device.data.params before sensors() is called, so
+            # check it directly here instead of waiting for the first
+            # coordinator tick.
+            enabled = len(self._mqtt_key_expr.find(device.data.params)) > 0
         self._attr_entity_registry_enabled_default = enabled
         self._attr_entity_registry_visible_default = enabled
         self._attr_available = enabled


### PR DESCRIPTION
`auto_enable` flips `entity_registry_enabled_default`/`visible_default` inside `_updated()`, but HA reads that default synchronously when the entity is first added — before any coordinator update, so before `_updated()` can have run. On a fresh setup every `auto_enable` entity registers hidden/disabled regardless of whether its key has data, and never self-corrects afterward. Affects ~76 registrations across 12 device files (`delta2`, `delta2_max`, `delta3_1500`, `delta_max`, `delta_pro`, `delta_pro_3`, `river_max`, `river_pro`, `stream_ac` public+internal, `stream_microinverter` public+internal, `smart_home_panel`).

Fix: `device.data.params` is already populated by `quota_all()` before `sensors()` runs, so check it at construction time with the same jsonpath expression `_updated()` uses, instead of waiting for a tick that comes too late:

```python
self._auto_enable = auto_enable
if auto_enable and not enabled:
    enabled = len(self._mqtt_key_expr.find(device.data.params)) > 0
self._attr_entity_registry_enabled_default = enabled
self._attr_entity_registry_visible_default = enabled
self._attr_available = enabled
```

Single change in `entities/__init__.py`, no device files touched.

Tested: jsonpath lookup verified in isolation (flat + nested key forms), full-tree `compileall`, deployed live alongside my other changes on a Stream Microinverter setup (Public + private API entries) — no regressions, both entries load and update normally. Have not yet been able to exercise the actual auto-enable-on-fresh-registration path live (would require removing and re-adding a whole device), so flagging that as unverified in practice even though the logic is straightforward.