### PR TITLE
fix(config-flow): strip pasted API keys, and make auth failures recoverable

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -1,13 +1,18 @@
 import logging
 from typing import Any, Final
 
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.ecoflow_cloud.api import EcoflowApiClient
+from custom_components.ecoflow_cloud.api import (
+    EcoflowApiClient,
+    EcoflowAuthException,
+    EcoflowException,
+)
 
 from . import _preload_proto  # noqa: F401 # pyright: ignore[reportUnusedImport]
 from .device_data import DeviceData, DeviceOptions
@@ -267,10 +272,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Try to connect and authenticate
     try:
         await api_client.login()
-    except (ConnectionError, TimeoutError) as ex:
-        # Transient network issues - retry later
+    except (ConnectionError, TimeoutError, aiohttp.ClientError) as ex:
+        # Transient network issues - retry later. aiohttp's connector errors are not
+        # ConnectionError subclasses, so they need naming separately
         _LOGGER.warning("Failed to connect to EcoFlow API: %s", ex)
         raise ConfigEntryNotReady(f"Connection failed: {ex}") from ex
+    except EcoflowAuthException as ex:
+        # Ask the user for new credentials instead of retrying with the rejected ones
+        raise ConfigEntryAuthFailed(str(ex)) from ex
+    except EcoflowException as ex:
+        # Any other API error may well be transient - let HA retry with backoff
+        _LOGGER.warning("EcoFlow API login failed: %s", ex)
+        raise ConfigEntryNotReady(f"Login failed: {ex}") from ex
 
     # Fetch current device statuses from API
     try:

--- a/custom_components/ecoflow_cloud/api/__init__.py
+++ b/custom_components/ecoflow_cloud/api/__init__.py
@@ -12,8 +12,19 @@ from .message import JSONMessage, Message
 _LOGGER = logging.getLogger(__name__)
 
 
+# EcoFlow returns 8513 both for a bad access key and for one issued in another region
+PUBLIC_API_AUTH_ERROR_CODES = frozenset({"8513"})
+
+
 class EcoflowException(Exception):
-    pass
+    def __init__(self, message: str, code: str | None = None):
+        super().__init__(message)
+        # EcoFlow's numeric error code, when the failure came from an API response
+        self.code = code
+
+
+class EcoflowAuthException(EcoflowException):
+    """Credentials were rejected - retrying with the same ones will not help."""
 
 
 @dataclass
@@ -113,7 +124,11 @@ class EcoflowApiClient(ABC):
             raise EcoflowException(f"Failed to parse response: {resp.text} Error: {error}")
 
         if response_message.lower() != "success":
-            raise EcoflowException(f"{response_message}")
+            raw_code = json_resp.get("code")
+            code = None if raw_code is None else str(raw_code)
+            if code in PUBLIC_API_AUTH_ERROR_CODES:
+                raise EcoflowAuthException(f"{response_message}", code=code)
+            raise EcoflowException(f"{response_message}", code=code)
 
         return json_resp
 

--- a/custom_components/ecoflow_cloud/api/private_api.py
+++ b/custom_components/ecoflow_cloud/api/private_api.py
@@ -8,7 +8,7 @@ import aiohttp
 from homeassistant.util import uuid
 
 from ..devices import EcoflowDeviceInfo
-from . import EcoflowApiClient, EcoflowException
+from . import EcoflowApiClient, EcoflowAuthException, EcoflowException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,14 @@ class EcoflowPrivateApiClient(EcoflowApiClient):
             _LOGGER.info(f"Login to EcoFlow API {url}")
 
             resp = await session.post(url, headers=headers, json=data)
-            response = await self._get_json_response(resp)
+            try:
+                response = await self._get_json_response(resp)
+            except EcoflowException as error:
+                # an error code from /auth/login means the credentials were rejected;
+                # transport and parse failures carry no code and stay retryable
+                if error.code is None:
+                    raise
+                raise EcoflowAuthException(str(error), code=error.code) from error
 
             try:
                 self.token = response["data"]["token"]

--- a/custom_components/ecoflow_cloud/api/public_api.py
+++ b/custom_components/ecoflow_cloud/api/public_api.py
@@ -1,13 +1,13 @@
-from typing import Any
-
-from custom_components.ecoflow_cloud.devices.data_holder import PreparedData
 import hashlib
 import hmac
 import logging
 import random
 import time
+from typing import Any
 
 import aiohttp
+
+from custom_components.ecoflow_cloud.devices.data_holder import PreparedData
 
 from ..devices import EcoflowDeviceInfo
 from . import EcoflowApiClient
@@ -26,8 +26,9 @@ class EcoflowPublicApiClient(EcoflowApiClient):
     def __init__(self, api_domain: str, access_key: str, secret_key: str, group: str):
         super().__init__()
         self.api_domain = api_domain
-        self.access_key = access_key
-        self.secret_key = secret_key
+        # strip here too: entries stored before the config flow sanitized them
+        self.access_key = access_key.strip()
+        self.secret_key = secret_key.strip()
         self.group = group
         self.nonce = str(random.randint(10000, 1000000))
         self.timestamp = str(int(time.time() * 1000))
@@ -42,7 +43,7 @@ class EcoflowPublicApiClient(EcoflowApiClient):
         _LOGGER.info("Requesting all devices")
         response = await self.call_api("/device/list")
         _LOGGER.info(f"Received devices: \n {response}")
-        result = list()
+        result = []
         for device in response["data"]:
             _LOGGER.debug(str(device))
             sn = device["sn"]
@@ -74,9 +75,8 @@ class EcoflowPublicApiClient(EcoflowApiClient):
                 raw = await self.call_api("/device/quota/all", {"sn": sn})
                 if "data" in raw:
                     self.devices[sn].data.add_data(PreparedData(None, {"params": raw["data"]}, raw, False))
-            except Exception as exception:
-                _LOGGER.error(exception, exc_info=True)
-                _LOGGER.error("Error retrieving %s", sn)
+            except Exception:
+                _LOGGER.exception("Error retrieving %s", sn)
 
     async def call_api(self, endpoint: str, params: dict[str, str] | None = None) -> dict:
         self.nonce = str(random.randint(10000, 1000000))

--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
 
@@ -46,7 +47,7 @@ from custom_components.ecoflow_cloud import (
     extract_devices,
 )
 
-from .api import EcoflowException
+from .api import EcoflowAuthException, EcoflowException
 from .devices import EcoflowDeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -197,6 +198,55 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
         self.set_current_config_entry(self.hass.config_entries.async_get_entry(self.context["entry_id"]))
         return await self.async_step_user()
 
+    async def async_step_reauth(self, entry_data: Mapping[str, Any] | None = None):
+        self.set_current_config_entry(self.hass.config_entries.async_get_entry(self.context["entry_id"]))
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
+        public_api = CONF_ACCESS_KEY in self.new_data
+
+        # HA fills "name" from the entry title on newer cores; set it so older ones match
+        placeholders = {"name": self.new_data.get(CONF_GROUP, "")}
+
+        if not user_input:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=self._schema_for(public_api),
+                description_placeholders=placeholders,
+            )
+
+        if public_api:
+            self._set_api_credentials(user_input)
+            self.auth = self._create_api_client()
+        else:
+            self._set_manual_credentials(user_input)
+            self.auth = self._create_manual_client()
+
+        errors: dict[str, str] = {}
+        try:
+            await self.auth.login()
+        except EcoflowAuthException as e:
+            errors["base"] = "invalid_access_key" if public_api else str(e)
+        except EcoflowException as e:
+            errors["base"] = str(e)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception in reauth login action")
+            return self.async_abort(reason="unknown")
+
+        if errors:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=self._schema_for(public_api),
+                errors=errors,
+                description_placeholders=placeholders,
+            )
+
+        # credentials only: the device list and its options stay as they were
+        self.hass.config_entries.async_update_entry(entry=self.config_entry, data=self.new_data)
+        # unconditional: the entry is in a failed state even when the data did not change
+        self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+        return self.async_abort(reason="reauth_successful")
+
     async def async_step_choose_type(self, user_input: dict[str, Any] | None = None):
         if self.config_entry:  # reconfig flow
             if CONF_ACCESS_KEY in self.config_entry.data:
@@ -207,30 +257,71 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
         if not user_input:
             return self.async_show_menu(step_id="choose_type", menu_options=["api", "manual"])
 
-    async def async_step_manual(self, user_input: dict[str, Any] | None = None):
-        user_auth_schema = vol.Schema(
+    def _manual_schema(self) -> vol.Schema:
+        return vol.Schema(
             {
-                vol.Required(CONF_API_HOST, default="api.ecoflow.com"): str,
+                vol.Required(CONF_API_HOST, default=self.new_data.get(CONF_API_HOST, "api.ecoflow.com")): str,
                 vol.Required(CONF_USERNAME, default=self.new_data.get(CONF_USERNAME, "")): str,
                 vol.Required(CONF_PASSWORD, default=self.new_data.get(CONF_PASSWORD, "")): str,
             }
         )
 
-        if not user_input:
-            return self.async_show_form(step_id="manual", data_schema=user_auth_schema)
+    def _api_schema(self) -> vol.Schema:
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_API_HOST, default=self.new_data.get(CONF_API_HOST, "api-e.ecoflow.com")
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=["api-e.ecoflow.com", "api-a.ecoflow.com"],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    ),
+                ),
+                vol.Required(CONF_ACCESS_KEY, default=self.new_data.get(CONF_ACCESS_KEY, "")): str,
+                vol.Required(CONF_SECRET_KEY, default=self.new_data.get(CONF_SECRET_KEY, "")): str,
+            }
+        )
 
+    def _schema_for(self, public_api: bool) -> vol.Schema:
+        return self._api_schema() if public_api else self._manual_schema()
+
+    def _set_manual_credentials(self, user_input: dict[str, Any]) -> None:
         self.new_data[CONF_API_HOST] = user_input.get(CONF_API_HOST)
         self.new_data[CONF_USERNAME] = user_input.get(CONF_USERNAME)
         self.new_data[CONF_PASSWORD] = user_input.get(CONF_PASSWORD)
 
+    def _set_api_credentials(self, user_input: dict[str, Any]) -> None:
+        self.new_data[CONF_API_HOST] = user_input.get(CONF_API_HOST)
+        # keys get pasted from the developer portal, often with stray whitespace that breaks the signature
+        self.new_data[CONF_ACCESS_KEY] = user_input.get(CONF_ACCESS_KEY, "").strip()
+        self.new_data[CONF_SECRET_KEY] = user_input.get(CONF_SECRET_KEY, "").strip()
+
+    def _create_manual_client(self):
         from .api.private_api import EcoflowPrivateApiClient
 
-        self.auth = EcoflowPrivateApiClient(
+        return EcoflowPrivateApiClient(
             self.new_data[CONF_API_HOST],
             self.new_data[CONF_USERNAME],
             self.new_data[CONF_PASSWORD],
             self.new_data[CONF_GROUP],
         )
+
+    def _create_api_client(self):
+        from .api.public_api import EcoflowPublicApiClient
+
+        return EcoflowPublicApiClient(
+            self.new_data[CONF_API_HOST],
+            self.new_data[CONF_ACCESS_KEY],
+            self.new_data[CONF_SECRET_KEY],
+            self.new_data[CONF_GROUP],
+        )
+
+    async def async_step_manual(self, user_input: dict[str, Any] | None = None):
+        if not user_input:
+            return self.async_show_form(step_id="manual", data_schema=self._manual_schema())
+
+        self._set_manual_credentials(user_input)
+        self.auth = self._create_manual_client()
 
         errors: dict[str, str] = {}
         try:
@@ -242,7 +333,7 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
             return self.async_abort(reason="unknown")
 
         if errors:
-            return self.async_show_form(step_id="manual", data_schema=user_auth_schema, errors=errors)
+            return self.async_show_form(step_id="manual", data_schema=self._manual_schema(), errors=errors)
 
         if self.config_entry:  # reconfig flow
             devices = extract_devices(self.config_entry)
@@ -303,40 +394,17 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
         return await self.update_or_create()
 
     async def async_step_api(self, user_input: dict[str, Any] | None = None):
-        api_keys_auth_schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_API_HOST, default=self.new_data.get(CONF_API_HOST, "api-e.ecoflow.com")
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=["api-e.ecoflow.com", "api-a.ecoflow.com"],
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    ),
-                ),
-                vol.Required(CONF_ACCESS_KEY, default=self.new_data.get(CONF_ACCESS_KEY, "")): str,
-                vol.Required(CONF_SECRET_KEY, default=self.new_data.get(CONF_SECRET_KEY, "")): str,
-            }
-        )
-
         if not user_input:
-            return self.async_show_form(step_id="api", data_schema=api_keys_auth_schema)
+            return self.async_show_form(step_id="api", data_schema=self._api_schema())
 
-        self.new_data[CONF_API_HOST] = user_input.get(CONF_API_HOST)
-        self.new_data[CONF_ACCESS_KEY] = user_input.get(CONF_ACCESS_KEY)
-        self.new_data[CONF_SECRET_KEY] = user_input.get(CONF_SECRET_KEY)
-
-        from .api.public_api import EcoflowPublicApiClient
-
-        self.auth = EcoflowPublicApiClient(
-            self.new_data[CONF_API_HOST],
-            self.new_data[CONF_ACCESS_KEY],
-            self.new_data[CONF_SECRET_KEY],
-            self.new_data[CONF_GROUP],
-        )
+        self._set_api_credentials(user_input)
+        self.auth = self._create_api_client()
 
         errors: dict[str, str] = {}
         try:
             await self.auth.login()
+        except EcoflowAuthException:
+            errors["base"] = "invalid_access_key"
         except EcoflowException as e:  # pylint: disable=broad-except
             errors["base"] = str(e)
         except Exception:  # pylint: disable=broad-except
@@ -344,7 +412,8 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
             return self.async_abort(reason="unknown")
 
         if errors:
-            return self.async_show_form(step_id="api", data_schema=api_keys_auth_schema, errors=errors)
+            # rebuilt, not reused: the schema defaults now carry the credentials just entered
+            return self.async_show_form(step_id="api", data_schema=self._api_schema(), errors=errors)
 
         if self.config_entry:  # reconfig flow
             devices = extract_devices(self.config_entry)

--- a/custom_components/ecoflow_cloud/translations/de.json
+++ b/custom_components/ecoflow_cloud/translations/de.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlow hat den Zugriffsschlüssel abgelehnt (Fehler 8513). Zugriffs- und Geheimschlüssel auf Tippfehler prüfen und sicherstellen, dass der API-Host zur Region des Entwicklerkontos passt: api-e.ecoflow.com für Europa, api-a.ecoflow.com für Amerika."
+        },
+        "abort": {
+            "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+            "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
+            "do_reconfigure_existing": "Eine Gerätegruppe mit diesem Namen existiert bereits. Stattdessen den vorhandenen Eintrag neu konfigurieren.",
+            "no_device_to_add": "Keine neuen Geräte zum Hinzufügen: Alle Geräte dieses Kontos wurden bereits hinzugefügt.",
+            "remove_last_device": "Das letzte Gerät kann nicht entfernt werden. Stattdessen den Integrationseintrag löschen.",
+            "unknown": "Unerwarteter Fehler"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "EcoFlow-Zugangsdaten abgelehnt",
+                "description": "EcoFlow akzeptiert die gespeicherten Zugangsdaten für {name} nicht mehr. Bitte die aktuellen Zugangsdaten eingeben, um die Verbindung wiederherzustellen.",
+                "data": {
+                    "api_host": "API-Host",
+                    "access_key": "Zugriffsschlüssel",
+                    "secret_key": "Geheimschlüssel",
+                    "username": "Benutzer-E-Mail",
+                    "password": "Benutzerpasswort"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Gerätegruppe"
@@ -14,6 +36,7 @@
                     "finish": "Abschließen"
                 },
                 "data": {
+                    "api_host": "API-Host",
                     "access_key": "Zugriffsschlüssel",
                     "secret_key": "Geheimschlüssel",
                     "load_all_devices": "Automatisches Laden von Geräten"
@@ -44,6 +67,7 @@
                     "finish": "Abschließen"
                 },
                 "data": {
+                    "api_host": "API-Host",
                     "username": "Benutzer-E-Mail",
                     "password": "Benutzerpasswort"
                 }

--- a/custom_components/ecoflow_cloud/translations/en.json
+++ b/custom_components/ecoflow_cloud/translations/en.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlow rejected the access key (error 8513). Check the key and secret for typos, and make sure the API host matches the region your developer account belongs to: api-e.ecoflow.com for Europe, api-a.ecoflow.com for the Americas."
+        },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Reconfiguration was successful",
+            "do_reconfigure_existing": "A device group with this name already exists. Reconfigure that entry instead.",
+            "no_device_to_add": "No new devices to add: every device in this account has already been added.",
+            "remove_last_device": "The last device cannot be removed. Delete the integration entry instead.",
+            "unknown": "Unexpected error"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "EcoFlow credentials rejected",
+                "description": "EcoFlow no longer accepts the stored credentials for {name}. Enter the current ones to reconnect.",
+                "data": {
+                    "api_host": "API host",
+                    "access_key": "Access key",
+                    "secret_key": "Secret key",
+                    "username": "User email",
+                    "password": "User password"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Device group"
@@ -14,6 +36,7 @@
                     "finish": "Finish"
                 },
                 "data": {
+                    "api_host": "API host",
                     "access_key": "Access key",
                     "secret_key": "Secret key",
                     "load_all_devices": "Automatic device loading"
@@ -44,6 +67,7 @@
                     "finish": "Finish"
                 },
                 "data": {
+                    "api_host": "API host",
                     "username": "User email",
                     "password": "User password"
                 }

--- a/custom_components/ecoflow_cloud/translations/fr.json
+++ b/custom_components/ecoflow_cloud/translations/fr.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlow a rejeté la clé d'accès (erreur 8513). Vérifiez que la clé d'accès et la clé secrète ne contiennent pas de fautes de frappe, et assurez-vous que l'hôte API correspond à la région de votre compte développeur : api-e.ecoflow.com pour l'Europe, api-a.ecoflow.com pour les Amériques."
+        },
+        "abort": {
+            "reauth_successful": "La réauthentification a réussi",
+            "reconfigure_successful": "La reconfiguration a réussi",
+            "do_reconfigure_existing": "Un groupe d'appareils portant ce nom existe déjà. Reconfigurez plutôt l'entrée existante.",
+            "no_device_to_add": "Aucun nouvel appareil à ajouter : tous les appareils de ce compte ont déjà été ajoutés.",
+            "remove_last_device": "Le dernier appareil ne peut pas être supprimé. Supprimez plutôt l'entrée d'intégration.",
+            "unknown": "Erreur inattendue"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "Identifiants EcoFlow rejetés",
+                "description": "EcoFlow n'accepte plus les identifiants enregistrés pour {name}. Saisissez les identifiants actuels pour rétablir la connexion.",
+                "data": {
+                    "api_host": "Hôte API",
+                    "access_key": "Clé d'accès",
+                    "secret_key": "Clé secrète",
+                    "username": "E-mail de l'utilisateur",
+                    "password": "Mot de passe de l'utilisateur"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Groupe d'appareils"
@@ -14,6 +36,7 @@
                     "finish": "Terminer"
                 },
                 "data": {
+                    "api_host": "Hôte API",
                     "access_key": "Clé d'accès",
                     "secret_key": "Clé secrète",
                     "load_all_devices": "Chargement automatique des appareils"
@@ -44,6 +67,7 @@
                     "finish": "Terminer"
                 },
                 "data": {
+                    "api_host": "Hôte API",
                     "username": "E-mail de l'utilisateur",
                     "password": "Mot de passe de l'utilisateur"
                 }

--- a/custom_components/ecoflow_cloud/translations/it.json
+++ b/custom_components/ecoflow_cloud/translations/it.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlow ha rifiutato la access key (errore 8513). Controlla che access key e secret key non contengano errori di battitura e verifica che l'host API corrisponda alla regione del tuo account sviluppatore: api-e.ecoflow.com per l'Europa, api-a.ecoflow.com per le Americhe."
+        },
+        "abort": {
+            "reauth_successful": "La riautenticazione è avvenuta con successo",
+            "reconfigure_successful": "La riconfigurazione è avvenuta con successo",
+            "do_reconfigure_existing": "Esiste già un gruppo di dispositivi con questo nome. Riconfigura invece la voce esistente.",
+            "no_device_to_add": "Nessun nuovo dispositivo da aggiungere: tutti i dispositivi di questo account sono già stati aggiunti.",
+            "remove_last_device": "L'ultimo dispositivo non può essere rimosso. Elimina invece la voce dell'integrazione.",
+            "unknown": "Errore imprevisto"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "Credenziali EcoFlow rifiutate",
+                "description": "EcoFlow non accetta più le credenziali salvate per {name}. Inserisci quelle attuali per riconnetterti.",
+                "data": {
+                    "api_host": "Host API",
+                    "access_key": "Access key",
+                    "secret_key": "Secret key",
+                    "username": "Email utente",
+                    "password": "Password utente"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Gruppo di dispositivi"
@@ -14,6 +36,7 @@
                     "finish": "Fine"
                 },
                 "data": {
+                    "api_host": "Host API",
                     "access_key": "Access key",
                     "secret_key": "Secret key",
                     "load_all_devices": "Caricamento automatico dei dispositivi"
@@ -44,6 +67,7 @@
                     "finish": "Fine"
                 },
                 "data": {
+                    "api_host": "Host API",
                     "username": "Email utente",
                     "password": "Password utente"
                 }

--- a/custom_components/ecoflow_cloud/translations/ja.json
+++ b/custom_components/ecoflow_cloud/translations/ja.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlowがアクセスキーを拒否しました（エラー8513）。アクセスキーとシークレットキーに入力ミスがないか確認し、APIホストが開発者アカウントのリージョンと一致しているか確認してください。ヨーロッパはapi-e.ecoflow.com、南北アメリカはapi-a.ecoflow.comです。"
+        },
+        "abort": {
+            "reauth_successful": "再認証に成功しました",
+            "reconfigure_successful": "再構成は成功しました",
+            "do_reconfigure_existing": "この名前のデバイスグループはすでに存在します。既存のエントリを再構成してください。",
+            "no_device_to_add": "追加できる新しいデバイスはありません。このアカウントのすべてのデバイスは追加済みです。",
+            "remove_last_device": "最後のデバイスは削除できません。代わりに統合のエントリを削除してください。",
+            "unknown": "予期しないエラー"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "EcoFlowの認証情報が拒否されました",
+                "description": "EcoFlowは{name}に保存されている認証情報を受け付けなくなりました。再接続するには現在の認証情報を入力してください。",
+                "data": {
+                    "api_host": "APIホスト",
+                    "access_key": "アクセスキー",
+                    "secret_key": "シークレットキー",
+                    "username": "ユーザーメールアドレス",
+                    "password": "ユーザーパスワード"
+                }
+            },
             "user": {
                 "data": {
                     "group": "デバイスグループ"
@@ -14,6 +36,7 @@
                     "finish": "完了"
                 },
                 "data": {
+                    "api_host": "APIホスト",
                     "access_key": "アクセスキー",
                     "secret_key": "シークレットキー",
                     "load_all_devices": "自動デバイス読み込み"
@@ -44,6 +67,7 @@
                     "finish": "完了"
                 },
                 "data": {
+                    "api_host": "APIホスト",
                     "username": "ユーザーメールアドレス",
                     "password": "ユーザーパスワード"
                 }

--- a/custom_components/ecoflow_cloud/translations/pl.json
+++ b/custom_components/ecoflow_cloud/translations/pl.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlow odrzucił klucz dostępu (błąd 8513). Sprawdź, czy klucz dostępu i klucz tajny nie zawierają literówek, oraz upewnij się, że host API odpowiada regionowi Twojego konta dewelopera: api-e.ecoflow.com dla Europy, api-a.ecoflow.com dla obu Ameryk."
+        },
+        "abort": {
+            "reauth_successful": "Ponowne uwierzytelnienie się powiodło",
+            "reconfigure_successful": "Ponowna konfiguracja się powiodła",
+            "do_reconfigure_existing": "Grupa urządzeń o tej nazwie już istnieje. Zamiast tego skonfiguruj ponownie istniejący wpis.",
+            "no_device_to_add": "Brak nowych urządzeń do dodania: wszystkie urządzenia z tego konta zostały już dodane.",
+            "remove_last_device": "Nie można usunąć ostatniego urządzenia. Zamiast tego usuń wpis integracji.",
+            "unknown": "Nieoczekiwany błąd"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "Dane logowania EcoFlow zostały odrzucone",
+                "description": "EcoFlow nie akceptuje już zapisanych danych logowania dla {name}. Wprowadź aktualne dane, aby połączyć się ponownie.",
+                "data": {
+                    "api_host": "Host API",
+                    "access_key": "Klucz dostępu",
+                    "secret_key": "Klucz tajny",
+                    "username": "Adres e-mail użytkownika",
+                    "password": "Hasło użytkownika"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Grupa urządzeń"
@@ -14,6 +36,7 @@
                     "finish": "Zakończ"
                 },
                 "data": {
+                    "api_host": "Host API",
                     "access_key": "Klucz dostępu",
                     "secret_key": "Klucz tajny",
                     "load_all_devices": "Automatyczne ładowanie urządzeń"
@@ -44,6 +67,7 @@
                     "finish": "Zakończ"
                 },
                 "data": {
+                    "api_host": "Host API",
                     "username": "Adres e-mail użytkownika",
                     "password": "Hasło użytkownika"
                 }

--- a/custom_components/ecoflow_cloud/translations/pt.json
+++ b/custom_components/ecoflow_cloud/translations/pt.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "A EcoFlow rejeitou a chave de acesso (erro 8513). Verifique se a chave de acesso e a chave secreta não têm erros de escrita e confirme que o host da API corresponde à região da sua conta de programador: api-e.ecoflow.com para a Europa, api-a.ecoflow.com para as Américas."
+        },
+        "abort": {
+            "reauth_successful": "Reautenticação bem sucedida",
+            "reconfigure_successful": "A reconfiguração foi bem sucedida",
+            "do_reconfigure_existing": "Já existe um grupo de dispositivos com este nome. Reconfigure a entrada existente.",
+            "no_device_to_add": "Não há novos dispositivos para adicionar: todos os dispositivos desta conta já foram adicionados.",
+            "remove_last_device": "Não é possível remover o último dispositivo. Elimine a entrada da integração.",
+            "unknown": "Erro inesperado"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "Credenciais EcoFlow rejeitadas",
+                "description": "A EcoFlow já não aceita as credenciais guardadas para {name}. Introduza as credenciais atuais para voltar a ligar.",
+                "data": {
+                    "api_host": "Host da API",
+                    "access_key": "Chave de acesso",
+                    "secret_key": "Chave secreta",
+                    "username": "E-mail do usuário",
+                    "password": "Senha do usuário"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Grupo de dispositivos"
@@ -14,6 +36,7 @@
                     "finish": "Concluir"
                 },
                 "data": {
+                    "api_host": "Host da API",
                     "access_key": "Chave de acesso",
                     "secret_key": "Chave secreta",
                     "load_all_devices": "Carregamento automático de dispositivos"
@@ -44,6 +67,7 @@
                     "finish": "Concluir"
                 },
                 "data": {
+                    "api_host": "Host da API",
                     "username": "E-mail do usuário",
                     "password": "Senha do usuário"
                 }

--- a/custom_components/ecoflow_cloud/translations/uk.json
+++ b/custom_components/ecoflow_cloud/translations/uk.json
@@ -1,7 +1,29 @@
 {
     "title": "EcoFlow-Cloud",
     "config": {
+        "error": {
+            "invalid_access_key": "EcoFlow відхилив access key (помилка 8513). Перевірте access key і secret key на помилки та переконайтеся, що хост API відповідає регіону вашого облікового запису розробника: api-e.ecoflow.com для Європи, api-a.ecoflow.com для Америки."
+        },
+        "abort": {
+            "reauth_successful": "Повторна автентифікація пройшла успішно",
+            "reconfigure_successful": "Переналаштування пройшло успішно",
+            "do_reconfigure_existing": "Група пристроїв з такою назвою вже існує. Переналаштуйте наявний запис.",
+            "no_device_to_add": "Немає нових пристроїв для додавання: усі пристрої цього облікового запису вже додано.",
+            "remove_last_device": "Останній пристрій не можна видалити. Замість цього видаліть запис інтеграції.",
+            "unknown": "Неочікувана помилка"
+        },
         "step": {
+            "reauth_confirm": {
+                "title": "EcoFlow відхилив облікові дані",
+                "description": "EcoFlow більше не приймає збережені облікові дані для {name}. Введіть актуальні, щоб відновити з'єднання.",
+                "data": {
+                    "api_host": "Хост API",
+                    "access_key": "Access key",
+                    "secret_key": "Secret key",
+                    "username": "Email користувача",
+                    "password": "Password користувача"
+                }
+            },
             "user": {
                 "data": {
                     "group": "Група пристроїв"
@@ -14,6 +36,7 @@
                     "finish": "Завершити"
                 },
                 "data": {
+                    "api_host": "Хост API",
                     "access_key": "Access key",
                     "secret_key": "Secret key",
                     "load_all_devices": "Автоматичне завантаження пристроїв"
@@ -44,6 +67,7 @@
                     "finish": "Завершити"
                 },
                 "data": {
+                    "api_host": "Хост API",
                     "username": "Email користувача",
                     "password": "Password користувача"
                 }


### PR DESCRIPTION
Closes #884.

### Whitespace in pasted credentials

Pasting an access/secret key from the EcoFlow developer portal usually brings trailing whitespace along, which goes straight into the HMAC-SHA256 signature and gets the request rejected as `signature is wrong`. Both keys are now stripped in the config flow **and** in `EcoflowPublicApiClient`, so entries that already stored a damaged key heal on the next reload instead of having to be re-entered.

### Error 8513

EcoFlow returns 8513 both for a mistyped key and for a key issued in the other region, and the flow surfaced it verbatim. `_get_json_response` now keeps the response code on the exception and raises `EcoflowAuthException` for 8513, which the flow maps to a translated message naming both causes and the `api-e` / `api-a` hosts.

### Setup no longer dies on a recoverable failure

`async_setup_entry` caught only `ConnectionError` / `TimeoutError`, so rejected credentials — and every `aiohttp.ClientError`, since `ClientConnectorError` is an `OSError` but not a `ConnectionError` — escaped uncaught and parked the entry in `SETUP_ERROR` with no retry and no prompt. A router reboot during startup was enough to leave the integration dead until someone reloaded it by hand.

| failure at login | before | after |
|---|---|---|
| rejected credentials | `SETUP_ERROR`, no prompt | `ConfigEntryAuthFailed` → reauth |
| `ClientConnectorError` / `ClientOSError` / `ClientResponseError` | `SETUP_ERROR`, no retry | `ConfigEntryNotReady` → retry |
| other API errors | `SETUP_ERROR`, no retry | `ConfigEntryNotReady` → retry |

`async_step_reauth` / `async_step_reauth_confirm` make the resulting reauth prompt actionable. Reauth rewrites credentials only — the device list and its per-device options are left untouched.

### Failed attempts no longer wipe the form

The schema was built once at the top of the step, from `new_data`, before the entered credentials were applied — so a failed attempt came back with every field blank and both keys had to be retyped, exactly when the error message is asking you to check them.

### Translations

Every config-flow error and abort reason is now defined in all eight languages (`reconfigure_successful` and the rest were rendering as raw keys), reusing HA core's own wording for the standard reasons so the dialogs read the same as every other integration. `api_host` gets a label in the `api` and `manual` steps.

`uk_UA.json` → `uk.json` and `pt-PT.json` → `pt.json`: HA loads `translations/{language}.json` by exact language code, so neither file had ever been read.

### Verification

`ruff check` (CI ignore list) and `mypy .` clean. Exception classification, both config-flow paths, the reauth flow and the schema rebuild were exercised against the real code with stubbed transports; the translation files were checked for key parity across all eight, and against HA's own `_validate_placeholders` so no key silently falls back to English. Confirmed in a live HA instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
