### PR TITLE
fix(wave2): follow the device's temperature unit for the setpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1793,7 +1793,7 @@ from Home Assistant.
 
 </p></details>
 
-<details><summary> WAVE_2 <i>(sensors: 27, sliders: 1, selects: 4)</i> </summary>
+<details><summary> WAVE_2 <i>(sensors: 27, sliders: 1, selects: 5)</i> </summary>
 <p>
 
 *Sensors*
@@ -1833,6 +1833,7 @@ from Home Assistant.
 - Main mode
 - Remote startup/shutdown
 - Sub-mode
+- Temperature unit
 
 </p></details>
 
@@ -2745,7 +2746,7 @@ from Home Assistant.
 
 </p></details>
 
-<details><summary> WAVE 2 (API) <i>(sensors: 27, sliders: 1, selects: 4)</i> </summary>
+<details><summary> WAVE 2 (API) <i>(sensors: 27, sliders: 1, selects: 5)</i> </summary>
 <p>
 
 *Sensors*
@@ -2785,6 +2786,7 @@ from Home Assistant.
 - Main mode
 - Remote startup/shutdown
 - Sub-mode
+- Temperature unit
 
 </p></details>
 

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -154,6 +154,11 @@ POWER_SUB_MODE_OPTIONS = {
     "Manual": 3
 }
 
+TEMP_UNIT_OPTIONS = {
+    "Celsius": 0,
+    "Fahrenheit": 1
+}
+
 POWER_SUPPLY_PRIORITY_OPTIONS = {
     "Prioritize power supply": 0,
     "Prioritize power storage": 1
@@ -348,6 +353,7 @@ FAN_MODE = "Wind speed"
 MAIN_MODE = "Main mode"
 REMOTE_MODE = "Remote startup/shutdown"
 POWER_SUB_MODE = "Sub-mode"
+TEMP_UNIT = "Temperature unit"
 
 
 # Smart Meter

--- a/custom_components/ecoflow_cloud/devices/internal/wave2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/wave2.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 from homeassistant.components.number import NumberEntity
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import UnitOfTemperature
 
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import BaseInternalDevice, const
@@ -16,6 +19,44 @@ from custom_components.ecoflow_cloud.sensor import (
     TempSensorEntity,
     WattsSensorEntity,
 )
+
+SETPOINT_RANGE_CELSIUS = (16, 30)
+SETPOINT_RANGE_FAHRENHEIT = (60, 86)
+
+
+class Wave2SetTempEntity(SetTempEntity):
+    """Setpoint entity that follows the unit the device itself is set to."""
+
+    _reported_unit: UnitOfTemperature | None = None
+
+    def _current_unit(self) -> UnitOfTemperature:
+        if str(self._device.data.params.get("pd.tempSys")).strip().lower() in {"1", "f", "fahrenheit"}:
+            return UnitOfTemperature.FAHRENHEIT
+        return UnitOfTemperature.CELSIUS
+
+    def _current_range(self) -> tuple[int, int]:
+        if self._current_unit() == UnitOfTemperature.FAHRENHEIT:
+            return SETPOINT_RANGE_FAHRENHEIT
+        return SETPOINT_RANGE_CELSIUS
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfTemperature | None:
+        return self._current_unit()
+
+    @property
+    def native_min_value(self) -> float:
+        return self._current_range()[0]
+
+    @property
+    def native_max_value(self) -> float:
+        return self._current_range()[1]
+
+    def _updated(self, data: dict[str, Any]):
+        super()._updated(data)
+        # A unit flip alone leaves setTemp untouched, so nothing else would repaint the entity.
+        if self._reported_unit != self._current_unit():
+            self._reported_unit = self._current_unit()
+            self.schedule_update_ha_state()
 
 
 class Wave2(BaseInternalDevice):
@@ -61,13 +102,12 @@ class Wave2(BaseInternalDevice):
 
     def numbers(self, client: EcoflowApiClient) -> list[NumberEntity]:
         return [
-            SetTempEntity(
+            Wave2SetTempEntity(
                 client,
                 self,
                 "pd.setTemp",
                 "Set Temperature",
-                0,
-                40,
+                *SETPOINT_RANGE_CELSIUS,
                 lambda value: {
                     "moduleType": 1,
                     "operateType": "setTemp",
@@ -129,6 +169,19 @@ class Wave2(BaseInternalDevice):
                     "operateType": "subMode",
                     "sn": self.device_info.sn,
                     "params": {"subMode": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "pd.tempSys",
+                const.TEMP_UNIT,
+                const.TEMP_UNIT_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "tempSys",
+                    "sn": self.device_info.sn,
+                    "params": {"mode": value},
                 },
             ),
         ]

--- a/custom_components/ecoflow_cloud/number.py
+++ b/custom_components/ecoflow_cloud/number.py
@@ -1,7 +1,8 @@
-from homeassistant.components.number.const import NumberDeviceClass
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from homeassistant.components.number import NumberMode
+from homeassistant.components.number.const import NumberDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
 from homeassistant.core import HomeAssistant
@@ -15,7 +16,7 @@ from .entities import BaseNumberEntity
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
     client: EcoflowApiClient = hass.data[ECOFLOW_DOMAIN][entry.entry_id]
-    for sn, device in client.devices.items():
+    for device in client.devices.values():
         async_add_entities(device.numbers(client))
 
 
@@ -162,4 +163,5 @@ class MaxWattsEntity(LevelEntity):
 
 
 class SetTempEntity(ValueUpdateEntity):
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS

--- a/docs/devices/WAVE_2-Public.md
+++ b/docs/devices/WAVE_2-Public.md
@@ -30,12 +30,13 @@
 - Status
 
 *Sliders (numbers)*
-- Set Temperature (`pd.setTemp` -> `{"moduleType": 1, "operateType": "setTemp", "sn": "SN", "params": {"setTemp": "VALUE"}}` [0 - 40])
+- Set Temperature (`pd.setTemp` -> `{"moduleType": 1, "operateType": "setTemp", "sn": "SN", "params": {"setTemp": "VALUE"}}` [16 - 30])
 
 *Selects*
 - Wind speed (`pd.fanValue` -> `{"moduleType": 1, "operateType": "fanValue", "sn": "SN", "params": {"fanValue": "VALUE"}}` [Low (0), Medium (1), High (2)])
 - Main mode (`pd.mainMode` -> `{"moduleType": 1, "operateType": "mainMode", "sn": "SN", "params": {"mainMode": "VALUE"}}` [Cool (0), Heat (1), Fan (2)])
 - Remote startup/shutdown (`pd.powerMode` -> `{"moduleType": 1, "operateType": "powerMode", "sn": "SN", "params": {"powerMode": "VALUE"}}` [Startup (1), Standby (2), Shutdown (3)])
 - Sub-mode (`pd.subMode` -> `{"moduleType": 1, "operateType": "subMode", "sn": "SN", "params": {"subMode": "VALUE"}}` [Max (0), Sleep (1), Eco (2), Manual (3)])
+- Temperature unit (`pd.tempSys` -> `{"moduleType": 1, "operateType": "tempSys", "sn": "SN", "params": {"mode": "VALUE"}}` [Celsius (0), Fahrenheit (1)])
 
 

--- a/docs/devices/WAVE_2.md
+++ b/docs/devices/WAVE_2.md
@@ -30,12 +30,13 @@
 - Status
 
 *Sliders (numbers)*
-- Set Temperature (`pd.setTemp` -> `{"moduleType": 1, "operateType": "setTemp", "sn": "SN", "params": {"setTemp": "VALUE"}}` [0 - 40])
+- Set Temperature (`pd.setTemp` -> `{"moduleType": 1, "operateType": "setTemp", "sn": "SN", "params": {"setTemp": "VALUE"}}` [16 - 30])
 
 *Selects*
 - Wind speed (`pd.fanValue` -> `{"moduleType": 1, "operateType": "fanValue", "sn": "SN", "params": {"fanValue": "VALUE"}}` [Low (0), Medium (1), High (2)])
 - Main mode (`pd.mainMode` -> `{"moduleType": 1, "operateType": "mainMode", "sn": "SN", "params": {"mainMode": "VALUE"}}` [Cool (0), Heat (1), Fan (2)])
 - Remote startup/shutdown (`pd.powerMode` -> `{"moduleType": 1, "operateType": "powerMode", "sn": "SN", "params": {"powerMode": "VALUE"}}` [Startup (1), Standby (2), Shutdown (3)])
 - Sub-mode (`pd.subMode` -> `{"moduleType": 1, "operateType": "subMode", "sn": "SN", "params": {"subMode": "VALUE"}}` [Max (0), Sleep (1), Eco (2), Manual (3)])
+- Temperature unit (`pd.tempSys` -> `{"moduleType": 1, "operateType": "tempSys", "sn": "SN", "params": {"mode": "VALUE"}}` [Celsius (0), Fahrenheit (1)])
 
 

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1736,7 +1736,7 @@
 
 </p></details>
 
-<details><summary> WAVE_2 <i>(sensors: 27, sliders: 1, selects: 4)</i> </summary>
+<details><summary> WAVE_2 <i>(sensors: 27, sliders: 1, selects: 5)</i> </summary>
 <p>
 
 *Sensors*
@@ -1776,6 +1776,7 @@
 - Main mode
 - Remote startup/shutdown
 - Sub-mode
+- Temperature unit
 
 </p></details>
 
@@ -2688,7 +2689,7 @@
 
 </p></details>
 
-<details><summary> WAVE 2 (API) <i>(sensors: 27, sliders: 1, selects: 4)</i> </summary>
+<details><summary> WAVE 2 (API) <i>(sensors: 27, sliders: 1, selects: 5)</i> </summary>
 <p>
 
 *Sensors*
@@ -2728,6 +2729,7 @@
 - Main mode
 - Remote startup/shutdown
 - Sub-mode
+- Temperature unit
 
 </p></details>
 


### PR DESCRIPTION
Fixes #888.

## The problem

Wave 2's `Set Temperature` number was bound to `pd.setTemp` with a hardcoded Celsius unit and a fixed `0 - 40` range. But the device reports `pd.setTemp` in whatever unit `pd.tempSys` is set to (`0` = Celsius, `1` = Fahrenheit), so a Wave 2 configured for Fahrenheit reports `68` — which HA rendered as `68` on a `0 - 40` °C slider.

Underneath that, `SetTempEntity` carried no `device_class`. HA only converts a number's value **and** its min/max when `device_class` is `TEMPERATURE`, so setpoints never followed the user's unit system while every temperature *sensor* (`TempSensorEntity`, which does set the device class) did. That asymmetry is the "self-contradictory" behaviour in the report.

## The change

- `SetTempEntity` gets `_attr_device_class = NumberDeviceClass.TEMPERATURE`.
- New `Wave2SetTempEntity` derives its native unit from `pd.tempSys` and switches the range between `16 - 30` °C and `60 - 86` °F, replacing the fixed `0 - 40`. This follows the existing `GlacierClassicSetTempEntity` precedent.
- New `Temperature unit` select (`operateType: "tempSys"`, `params: {"mode": 0|1}`) so the device can be flipped back to Celsius from HA.
- Docs/README regenerated via `mise run gendocs`.

The `setTemp` command payload is unchanged: HA passes `async_set_native_value` the already-converted native value, so the device still receives its own unit.

## Blast radius

`device_class` lands on the shared `SetTempEntity`, so Glacier and Glacier Classic setpoints now follow the user's unit system too — that is what #586 asks for on Glacier. Glacier Classic already tracks its own unit via `pd.tmpUnit` but keeps constructor-fixed bounds of `-20..20`, which were already wrong when that device is in Fahrenheit; this PR neither creates nor fixes that, and no case renders worse than before. Left as separate scope.

## Verification

The repo has no test suite, so this was checked with a throwaway harness that builds a real `Wave2` and feeds it quota params. Before the change:

```
FAIL device_class: expected TEMPERATURE, got None
FAIL native_unit_of_measurement: expected °F, got °C
  ok native_value: 68                       <- 68 on a 0-40 °C slider, the reported bug
FAIL native_min_value: expected 60, got 0
FAIL native_max_value: expected 86, got 40
AssertionError: no entity titled 'Temperature unit'
```

After: all checks pass, including the `pd.tempSys`-absent case falling back to Celsius (so firmware that never reports it behaves exactly as today). `mise run lint` (ruff + mypy, 92 files) is clean.

## One open assumption

I could not confirm first-hand that `pd.setTemp` tracks `pd.tempSys` on the reporter's firmware — the only public MQTT dump I found had the device in Celsius, where `setTemp == setTempCel`. The reported value of `68` (= 20 °C) is strong circumstantial evidence, and the Celsius fallback keeps unaffected devices unchanged. A diagnostics download showing `pd.tempSys`, `pd.setTemp`, `pd.setTempCel` and `pd.setTempfah` together would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
