### PR TITLE
fix(auth): keep private login failures retryable

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -12,6 +12,7 @@ from custom_components.ecoflow_cloud.api import (
     EcoflowApiClient,
     EcoflowAuthException,
     EcoflowException,
+    EcoflowPrivateApiLoginRejected,
 )
 
 from . import _preload_proto  # noqa: F401 # pyright: ignore[reportUnusedImport]
@@ -246,8 +247,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     api_client: EcoflowApiClient
     if ECOFLOW_DOMAIN not in hass.data:
         hass.data[ECOFLOW_DOMAIN] = {}
-    is_private_api = CONF_USERNAME in entry.data and CONF_PASSWORD in entry.data
-    if is_private_api:
+    if CONF_USERNAME in entry.data and CONF_PASSWORD in entry.data:
         from .api.private_api import EcoflowPrivateApiClient
 
         api_client = EcoflowPrivateApiClient(
@@ -278,15 +278,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # ConnectionError subclasses, so they need naming separately
         _LOGGER.warning("Failed to connect to EcoFlow API: %s", ex)
         raise ConfigEntryNotReady(f"Connection failed: {ex}") from ex
+    except EcoflowPrivateApiLoginRejected as ex:
+        # EcoFlow does not distinguish a transient private-service rejection from
+        # invalid stored credentials. Keep setup retryable; Reconfigure remains the
+        # explicit path for validating and replacing private credentials.
+        _LOGGER.warning("EcoFlow private API login rejected ambiguously: %s", ex)
+        raise ConfigEntryNotReady(f"Private API login rejected: {ex}") from ex
     except EcoflowAuthException as ex:
-        # EcoFlow's private endpoint also returns auth errors for transient service
-        # failures. Keep an already-configured entry retryable; users can still run
-        # Reconfigure when their credentials actually changed.
-        if is_private_api:
-            _LOGGER.warning("EcoFlow private API login rejected: %s", ex)
-            raise ConfigEntryNotReady(f"Private API login failed: {ex}") from ex
-
-        # Public API credential failures are deterministic enough to request reauth.
+        # Public API credential failures have a specific code and can request reauth.
         raise ConfigEntryAuthFailed(str(ex)) from ex
     except EcoflowException as ex:
         # Any other API error may well be transient - let HA retry with backoff

--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -246,7 +246,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     api_client: EcoflowApiClient
     if ECOFLOW_DOMAIN not in hass.data:
         hass.data[ECOFLOW_DOMAIN] = {}
-    if CONF_USERNAME in entry.data and CONF_PASSWORD in entry.data:
+    is_private_api = CONF_USERNAME in entry.data and CONF_PASSWORD in entry.data
+    if is_private_api:
         from .api.private_api import EcoflowPrivateApiClient
 
         api_client = EcoflowPrivateApiClient(
@@ -278,7 +279,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.warning("Failed to connect to EcoFlow API: %s", ex)
         raise ConfigEntryNotReady(f"Connection failed: {ex}") from ex
     except EcoflowAuthException as ex:
-        # Ask the user for new credentials instead of retrying with the rejected ones
+        # EcoFlow's private endpoint also returns auth errors for transient service
+        # failures. Keep an already-configured entry retryable; users can still run
+        # Reconfigure when their credentials actually changed.
+        if is_private_api:
+            _LOGGER.warning("EcoFlow private API login rejected: %s", ex)
+            raise ConfigEntryNotReady(f"Private API login failed: {ex}") from ex
+
+        # Public API credential failures are deterministic enough to request reauth.
         raise ConfigEntryAuthFailed(str(ex)) from ex
     except EcoflowException as ex:
         # Any other API error may well be transient - let HA retry with backoff

--- a/custom_components/ecoflow_cloud/api/__init__.py
+++ b/custom_components/ecoflow_cloud/api/__init__.py
@@ -27,6 +27,10 @@ class EcoflowAuthException(EcoflowException):
     """Credentials were rejected - retrying with the same ones will not help."""
 
 
+class EcoflowPrivateApiLoginRejected(EcoflowException):
+    """Private login was rejected without a reliable credential verdict."""
+
+
 @dataclass
 class EcoflowMqttInfo:
     url: str

--- a/custom_components/ecoflow_cloud/api/private_api.py
+++ b/custom_components/ecoflow_cloud/api/private_api.py
@@ -8,7 +8,7 @@ import aiohttp
 from homeassistant.util import uuid
 
 from ..devices import EcoflowDeviceInfo
-from . import EcoflowApiClient, EcoflowAuthException, EcoflowException
+from . import EcoflowApiClient, EcoflowException, EcoflowPrivateApiLoginRejected
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,11 +41,13 @@ class EcoflowPrivateApiClient(EcoflowApiClient):
             try:
                 response = await self._get_json_response(resp)
             except EcoflowException as error:
-                # an error code from /auth/login means the credentials were rejected;
-                # transport and parse failures carry no code and stay retryable
+                # The private endpoint uses coded login rejections for both bad
+                # credentials and transient service failures. Preserve that
+                # ambiguity so config-entry setup can retry without claiming a
+                # definitive credential failure.
                 if error.code is None:
                     raise
-                raise EcoflowAuthException(str(error), code=error.code) from error
+                raise EcoflowPrivateApiLoginRejected(str(error), code=error.code) from error
 
             try:
                 self.token = response["data"]["token"]

--- a/tests/test_setup_auth.py
+++ b/tests/test_setup_auth.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+from typing import Self, cast
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+
+from custom_components.ecoflow_cloud import (
+    CONF_ACCESS_KEY,
+    CONF_API_HOST,
+    CONF_GROUP,
+    CONF_PASSWORD,
+    CONF_SECRET_KEY,
+    CONF_USERNAME,
+    CONFIG_VERSION,
+    async_setup_entry,
+)
+from custom_components.ecoflow_cloud.api import (
+    EcoflowAuthException,
+    EcoflowPrivateApiLoginRejected,
+)
+from custom_components.ecoflow_cloud.api.private_api import EcoflowPrivateApiClient
+
+
+class _RejectedResponse:
+    status = 200
+    reason = "OK"
+    text = ""
+
+    async def json(self) -> dict[str, str]:
+        return {"message": "Account doesn't exist or incorrect password", "code": "1000"}
+
+
+class _RejectedSession:
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def post(self, *_args: object, **_kwargs: object) -> _RejectedResponse:
+        return _RejectedResponse()
+
+
+class SetupAuthTest(IsolatedAsyncioTestCase):
+    def _entry(self, data: dict[str, str]) -> SimpleNamespace:
+        return SimpleNamespace(
+            version=CONFIG_VERSION,
+            data={CONF_API_HOST: "api.example", CONF_GROUP: "Home", **data},
+            options={},
+            entry_id="entry-id",
+        )
+
+    async def test_ambiguous_private_rejection_stays_retryable(self) -> None:
+        entry = self._entry({CONF_USERNAME: "user", CONF_PASSWORD: "password"})
+        client = AsyncMock()
+        client.login.side_effect = EcoflowPrivateApiLoginRejected("rejected", code="1000")
+
+        with (
+            patch(
+                "custom_components.ecoflow_cloud.api.private_api.EcoflowPrivateApiClient",
+                return_value=client,
+            ),
+            patch("custom_components.ecoflow_cloud.extract_devices", return_value={}),
+            self.assertRaises(ConfigEntryNotReady),
+        ):
+            await async_setup_entry(
+                cast(HomeAssistant, SimpleNamespace(data={})), cast(ConfigEntry, entry)
+            )
+
+        client.login.assert_awaited_once_with()
+
+    async def test_private_coded_rejection_is_classified_as_ambiguous(self) -> None:
+        client = EcoflowPrivateApiClient("api.example", "user", "password", "Home")
+
+        with (
+            patch(
+                "custom_components.ecoflow_cloud.api.private_api.aiohttp.ClientSession",
+                return_value=_RejectedSession(),
+            ),
+            self.assertRaises(EcoflowPrivateApiLoginRejected) as raised,
+        ):
+            await client.login()
+
+        self.assertEqual(raised.exception.code, "1000")
+
+    async def test_definitive_public_auth_failure_starts_reauth(self) -> None:
+        entry = self._entry({CONF_ACCESS_KEY: "key", CONF_SECRET_KEY: "secret"})
+        client = AsyncMock()
+        client.login.side_effect = EcoflowAuthException("rejected", code="8513")
+
+        with (
+            patch(
+                "custom_components.ecoflow_cloud.api.public_api.EcoflowPublicApiClient",
+                return_value=client,
+            ),
+            patch("custom_components.ecoflow_cloud.extract_devices", return_value={}),
+            self.assertRaises(ConfigEntryAuthFailed),
+        ):
+            await async_setup_entry(
+                cast(HomeAssistant, SimpleNamespace(data={})), cast(ConfigEntry, entry)
+            )
+
+        client.login.assert_awaited_once_with()


### PR DESCRIPTION
## Summary

EcoFlow's private `/auth/login` response is not a reliable credential verdict. The endpoint can return the same coded rejection for invalid stored credentials and for a transient service failure, so counting one or more rejections cannot distinguish the two cases.

Represent a coded private-login rejection with a dedicated `EcoflowPrivateApiLoginRejected` exception. During config-entry setup, Home Assistant maps that ambiguous result to `ConfigEntryNotReady` and applies its native setup backoff. Public-API authentication failures remain `ConfigEntryAuthFailed`, because public error code `8513` is specific enough to start reauthentication.

The existing Reconfigure flow remains the explicit recovery path when private credentials really changed: it validates the submitted credentials before updating the config entry. The patch deliberately does not invent a retry count or claim that EcoFlow rejects valid credentials only once.

## Validation

- coded private `/auth/login` rejection is classified as ambiguous
- ambiguous private rejection becomes `ConfigEntryNotReady`
- definitive public authentication failure becomes `ConfigEntryAuthFailed`
- `python -m unittest discover -v tests`: 3 tests pass
- Ruff passes for the changed source and tests
- mypy passes for all 92 checked source and test files

## Known boundary

An actually invalid stored private password is indistinguishable from the observed transient response and therefore remains retryable until the user runs Reconfigure. Automatically switching to reauthentication after an arbitrary number of failures would recreate the original false credential verdict.
