### PR TITLE
fix(ocean-pro): derive Battery Power from PV+PCS, not per-pack field 44

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -75,6 +75,12 @@ F_PCS_TOTAL = 53
 BATTERY_PACK_CMD = (32, 177)  # (cmdFunc, cmdId)
 F_BATT_SLOT = 5
 F_BATT_PWR = 44
+# field 44 usually carries a sane per-pack power (watts), but intermittently
+# emits an implausible spike (tens to hundreds of kW for a single pack) that the
+# per-slot sum then amplifies. Reject any read beyond a pack's realistic share of
+# the inverter's rating (~24 kW / 4 packs, with generous headroom) as decode
+# noise, and keep the slot's last good value — same guard used for PV strings.
+BATT_PACK_MAX_W = 10_000
 
 
 def _first_num(fields: FieldMap, no: int) -> float | None:
@@ -170,7 +176,9 @@ class OceanProInverter(DeltaPro3):
     def _decode_battery(self, fields: FieldMap, result: dict[str, Any]) -> None:
         """Pack-reported battery power, summed across slots (cmdFunc 32 / cmdId 177)."""
         pwr = _first_num(fields, F_BATT_PWR)
-        if pwr is None:
+        # Missing, or an implausible spike (field-44 decode noise) — keep the
+        # last good per-slot values rather than poisoning the sum.
+        if pwr is None or abs(pwr) > BATT_PACK_MAX_W:
             return
         slot = _first_num(fields, F_BATT_SLOT)
         self._pack_pwr[int(slot) if slot is not None else 0] = round(pwr, 2)

--- a/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/ocean_pro.py
@@ -31,8 +31,6 @@ from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices.internal.delta_pro_3 import DeltaPro3
 from custom_components.ecoflow_cloud.devices.internal.smart_home_panel_3 import (
     WIRE_F32,
-    WIRE_F64,
-    WIRE_VARINT,
     FieldMap,
     SmartHomePanel3,
     _first,
@@ -68,28 +66,20 @@ PV_MAX_W = 5_500  # per-string MPPT ceiling; anything above is field-reuse noise
 # (negative = production/export).
 F_PCS_TOTAL = 53
 
-# Battery power is reported per pack in separate cmdFunc=32 / cmdId=177 frames:
-# field 44 = bp_power (W, signed: positive = charging, negative = discharging;
-# confirmed vs SoC direction, n=760), field 5 = pack slot index. Power adds
-# across packs, so track the last value per slot and sum.
-BATTERY_PACK_CMD = (32, 177)  # (cmdFunc, cmdId)
-F_BATT_SLOT = 5
-F_BATT_PWR = 44
-# field 44 usually carries a sane per-pack power (watts), but intermittently
-# emits an implausible spike (tens to hundreds of kW for a single pack) that the
-# per-slot sum then amplifies. Reject any read beyond a pack's realistic share of
-# the inverter's rating (~24 kW / 4 packs, with generous headroom) as decode
-# noise, and keep the slot's last good value — same guard used for PV strings.
-BATT_PACK_MAX_W = 10_000
-
-
-def _first_num(fields: FieldMap, no: int) -> float | None:
-    """First numeric value of a field regardless of wire type (varint or float)."""
-    for wt in (WIRE_F32, WIRE_VARINT, WIRE_F64):
-        v = _first(fields, no, wt)
-        if v is not None:
-            return float(v)
-    return None
+# Battery power is NOT read from per-pack field 44 (cmdFunc=32 / cmdId=177). That field
+# decodes to physically impossible values while charging — ~122 kW per pack and ~15 kA of
+# current, scaling with the pack count — so summing it per slot reported hundreds of kW.
+# A plausibility clamp on field 44 only turned the garbage into a *frozen* sensor: with
+# every charge frame rejected, Battery Power held its last discharge value for the entire
+# charge. Instead derive it from the reliable 254/21 stream by the DC-bus power balance:
+#
+#     battery power (+ = charge) = sum(pv1..pv8) + PCS total
+#
+# with PCS in its native sign (negative = production/export). Verified against a night
+# grid-charge (PV 0, PCS +20.7 kW -> +20.7 kW charge, matching grid 29.2 - home 8.6 kW)
+# and idle (-> 0). This is DC-bus power, so it reads a few % high vs true pack terminal
+# power (it ignores conversion loss) — an acceptable trade for a fresh, non-freezing value
+# that tracks SoC through a charge instead of freezing on it.
 
 
 class OceanPanel(SmartHomePanel3):
@@ -112,17 +102,13 @@ class OceanProInverter(DeltaPro3):
     inverter AC output, and pack-reported battery power.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        # Last-seen battery power per pack slot, summed into total battery power.
-        self._pack_pwr: dict[int, float] = {}
-
     @override
     def sensors(self, client: EcoflowApiClient) -> list[SensorEntity]:
         out: list[SensorEntity] = [
             # Inverter AC output; sign follows production (negative = export).
             WattsSensorEntity(client, self, "ocean_pcs_pwr", "Inverter Output Power").with_icon("mdi:sine-wave"),
-            # Pack-reported battery power (signed: + charge / - discharge).
+            # Battery power, derived from PV + PCS on the 254/21 stream (signed:
+            # + charge / - discharge). See the module note on why field 44 is not used.
             WattsSensorEntity(client, self, "ocean_batt_pwr", "Battery Power").with_icon("mdi:home-battery"),
             QuotaStatusSensorEntity(client, self),
         ]
@@ -153,8 +139,7 @@ class OceanProInverter(DeltaPro3):
                 fields = _parse_fields(pdata)
                 self._decode_pv(fields, result)
                 self._decode_pcs(fields, result)
-            elif cmd == BATTERY_PACK_CMD:
-                self._decode_battery(_parse_fields(pdata), result)
+                self._derive_battery_power(result)
         except Exception as e:  # reverse-engineered payload; never break the base decode
             _LOGGER.debug("Ocean Pro inverter field parse skipped: %s", e)
         return result
@@ -173,13 +158,20 @@ class OceanProInverter(DeltaPro3):
         if v is not None:
             result["ocean_pcs_pwr"] = round(v, 2)
 
-    def _decode_battery(self, fields: FieldMap, result: dict[str, Any]) -> None:
-        """Pack-reported battery power, summed across slots (cmdFunc 32 / cmdId 177)."""
-        pwr = _first_num(fields, F_BATT_PWR)
-        # Missing, or an implausible spike (field-44 decode noise) — keep the
-        # last good per-slot values rather than poisoning the sum.
-        if pwr is None or abs(pwr) > BATT_PACK_MAX_W:
+    def _derive_battery_power(self, result: dict[str, Any]) -> None:
+        """Battery power from the DC-bus balance: sum(pv1..pv8) + PCS total.
+
+        + = charging, - = discharging. Computed from this 254/21 frame's own PV and
+        PCS values (not persisted), so it is correctly PV=0 at night — the PV fields
+        are simply absent then — instead of holding a stale daytime sum. Requires PCS;
+        if the frame carried no PCS reading, leave the previous value untouched.
+        """
+        pcs = result.get("ocean_pcs_pwr")
+        if pcs is None:
             return
-        slot = _first_num(fields, F_BATT_SLOT)
-        self._pack_pwr[int(slot) if slot is not None else 0] = round(pwr, 2)
-        result["ocean_batt_pwr"] = round(sum(self._pack_pwr.values()), 2)
+        solar_in = sum(
+            result[f"pv{i}_pwr"]
+            for i in range(1, PV_STRINGS + 1)
+            if result.get(f"pv{i}_pwr")
+        )
+        result["ocean_batt_pwr"] = round(solar_in + pcs, 2)


### PR DESCRIPTION
## Problem
`Battery Power` on the Ocean Pro inverter (`OCEAN_PRO`, HR51) freezes for long stretches during charging. Observed: `-4936 W` held for ~48 min while SoC climbed 34→92% and the grid was actively charging (~20 kW into the pack). Panel (HR61) sensors, PV strings, and inverter output all stayed fresh throughout, and there were no errors in the log.

## Root cause
`Battery Power` was summed from per-pack field 44 (`cmdFunc=32 / cmdId=177`). During charging that field decodes to physically impossible values — ~122 kW **per pack** and ~15 kA of current, scaling with the pack count. The `BATT_PACK_MAX_W` clamp added in #894 correctly rejects those spikes, but by keeping the last good value it turns the garbage into a **frozen** sensor: every charge frame is rejected, so `Battery Power` holds its last *discharge* reading for the entire charge.

## Fix
Derive `Battery Power` from the reliable 254/21 stream via the DC-bus power balance, instead of field 44:

```
battery power (+ = charge) = sum(pv1..pv8) + PCS total   (PCS in its native sign, negative = production/export)
```

Computed from each 254/21 frame's own PV and PCS values (not persisted), so it reads 0-solar at night — the PV fields are simply absent then — rather than holding a stale daytime sum. This supersedes the field-44 path and its clamp for battery power (both removed).

**Caveats:**
- This is DC-bus (AC-side) power, so it reads a few % high vs true pack terminal power — it ignores conversion loss. A deliberate trade for a fresh value that tracks SoC through a charge instead of freezing on it.
- During **discharge**, the derived AC-side value can differ from the old per-pack DC field-44 reading by a few kW (e.g. −8,025 W derived vs −5,041 W field-44) — expected from AC-vs-DC plus field-44 quirks. The **direction always agrees**; the **charge case (the one that was broken) is exact**. Discharge magnitude is the softer case.

## Verification
Real HR51 hardware:
- Night grid-charge: PV 0 + PCS +20.7 kW → **+20.7 kW charge**, matching grid 29.2 − home 8.6 kW
- Idle → **0**
- Reproduced the freeze: field 44 read ~368 kW / ~15 kA during the same charge window
- **Independent HA-side check** via an interim template sensor replicating this exact logic (`Σpv + inverter_output_power`): a live charge read **+8,517 W** (correct, positive) where native `battery_power` would have been frozen; the discharge→charge sign flip (−8,025 → +8,517 W) tracked live with **no freeze**.

## Both sign directions confirmed
The derivation takes PCS in its native sign (negative = production/export). Both directions are now validated against ground truth (SoC direction, the method used to settle the field-44 sign):
- **Import / charge** (PCS positive): night grid-charge above.
- **Production / export** (PCS negative): across historical data, production samples (`pcs_total < −500 W`, **n=4,319**) agree with SoC direction **95.1%** — the ~5% disagreements are all sub-kW near-zero-crossing noise, not sign errors. Idle-while-producing residual is ~0.5 kW (loss/granularity). A grid-export sample (PV +14.3, PCS −13.1, grid −11.2 kW) derives **+1.2 kW charge** and balances.

Read-only; no control entities added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5hspf1Uq1wSRJRUKbrQLQ